### PR TITLE
지수 정보 삭제

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
@@ -3,15 +3,22 @@ package com.codeit.findex.domain.indexinfo.controller;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateResponse;
 import com.codeit.findex.domain.indexinfo.service.IndexInfoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "지수 정보 API", description = "지수 정보 관리 API")
 @RestController
 @RequestMapping("/api/index-infos")
 @RequiredArgsConstructor
@@ -24,5 +31,17 @@ public class IndexInfoController {
       @Valid @RequestBody IndexInfoCreateRequest request) {
     IndexInfoCreateResponse response = indexInfoService.createIndexInfo(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @Operation(summary = "지수 정보 삭제", description = "지수 정보를 삭제합니다. 관련된 지수 데이터도 함께 삭제됩니다.", operationId = "deleteIndexInfo")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "404", description = "삭제할 지수 정보를 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류"),
+      @ApiResponse(responseCode = "204", description = "지수 정보 삭제 성공")
+  })
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteIndexInfo(@PathVariable Long id) {
+    indexInfoService.deleteIndexInfo(id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
@@ -1,11 +1,11 @@
 package com.codeit.findex.domain.indexinfo.service;
 
-import com.codeit.findex.domain.common.enums.SourceType;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateResponse;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoMapper;
 import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
 import com.codeit.findex.domain.indexinfo.repository.IndexInfoRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,5 +41,13 @@ public class IndexInfoService {
     IndexInfo savedIndexInfo = indexInfoRepository.save(newIndexInfo);
 
     return indexInfoMapper.toIndexInfoCreateResponse(savedIndexInfo);
+  }
+
+  @Transactional
+  public void deleteIndexInfo(Long id) {
+    IndexInfo indexInfo = indexInfoRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException("지수 정보를 찾을 수 없습니다. ID: " + id));
+
+    indexInfoRepository.delete(indexInfo);
   }
 }

--- a/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.codeit.findex.global.error;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -18,6 +19,17 @@ public class GlobalExceptionHandler {
             .build();
 
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  @ExceptionHandler(EntityNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handlerEntityNotFoundException(EntityNotFoundException e) {
+    ErrorResponse response = ErrorResponse.builder()
+        .status(HttpStatus.NOT_FOUND.value())
+        .message("데이터를 찾을 수 없습니다.")
+        .details(e.getMessage())
+        .build();
+
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(Exception.class)

--- a/src/test/java/com/codeit/findex/domain/indexinfo/service/IndexInfoServiceTest.java
+++ b/src/test/java/com/codeit/findex/domain/indexinfo/service/IndexInfoServiceTest.java
@@ -2,21 +2,14 @@ package com.codeit.findex.domain.indexinfo.service;
 
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateResponse;
-import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
-import com.codeit.findex.domain.indexinfo.repository.IndexInfoRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
-
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional


### PR DESCRIPTION
## 작업 내용
지수 정보를 삭제하는 API 엔드포인트를 구현하고, 존재하지 않는 데이터 삭제 요청에 대한 예외 처리 로직을 추가했습니다.


## 변경 사항
- **API 구현**: 지수 정보 삭제를 위해 `Controller`, `Service` 레이어에 로직 작성
- **예외 처리**: `GlobalExceptionHandler`에 `EntityNotFoundException` 핸들러 추가
  - 삭제 시 ID를 찾지 못할 경우 적절한 에러 응답을 반환하도록 처리


## 테스트
- [x] 로컬 테스트 여부 (실제 API 호출 검증은 추후 진행)
  - 현재 로컬 빌드 성공 및 DB 정상 연결 상태까지만 확인했습니다.
- [x] 컨벤션 부합 여부

Closes #7