### PR TITLE
feat: 자동 연동 설정 목록 조회

### DIFF
--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/Service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/Service/AutoSyncConfigService.java
@@ -19,14 +19,27 @@ public class AutoSyncConfigService {
     }
 
     public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
-        List<AutoSyncConfig> autoSyncConfigs = autoSyncConfigRepository.findAll();
+        // 인덱스 ID와 활성화 여부가 조건, 이후 분기
+        Long indexInfoId = request.indexInfoId();
+        Boolean enabled = request.enabled();
+
+        List<AutoSyncConfig> autoSyncConfigs;
+
+        if (indexInfoId == null && enabled == null) {
+            autoSyncConfigs = autoSyncConfigRepository.findAll();
+        } else if (indexInfoId != null && enabled == null) {
+            autoSyncConfigs = autoSyncConfigRepository.findByIndexInfo_Id(indexInfoId);
+        } else if (indexInfoId == null) {
+            autoSyncConfigs = autoSyncConfigRepository.findByEnabled(enabled);
+        } else {
+            autoSyncConfigs = autoSyncConfigRepository.findByIndexInfo_IdAndEnabled(indexInfoId, enabled);
+        }
 
         List<AutoSyncConfigResponse> content = autoSyncConfigs.stream()
                 .map(this::toResponse)
                 .toList();
 
-        //페이지네이션 구현 이전 임시 응답 양식
-        return new AutoSyncConfigPageResponse(
+        return new AutoSyncConfigPageResponse( // 최종 응답 목록 반환
                 content,
                 null,
                 null,
@@ -35,7 +48,7 @@ public class AutoSyncConfigService {
                 false
         );
     }
-
+    // 개별 데이터 DTO 변환
     private AutoSyncConfigResponse toResponse(AutoSyncConfig autoSyncConfig) {
         return new AutoSyncConfigResponse(
                 autoSyncConfig.getId(),

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/Service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/Service/AutoSyncConfigService.java
@@ -5,57 +5,83 @@ import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigResponse;
 import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
 import com.codeit.findex.domain.autosyncconfig.repository.AutoSyncConfigRepository;
+import java.util.List;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 
 @Service
 public class AutoSyncConfigService {
 
-    private final AutoSyncConfigRepository autoSyncConfigRepository;
+  private final AutoSyncConfigRepository autoSyncConfigRepository;
 
-    public AutoSyncConfigService(AutoSyncConfigRepository autoSyncConfigRepository) {
-        this.autoSyncConfigRepository = autoSyncConfigRepository;
+  public AutoSyncConfigService(AutoSyncConfigRepository autoSyncConfigRepository) {
+    this.autoSyncConfigRepository = autoSyncConfigRepository;
+  }
+
+  public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
+    // 인덱스 ID와 활성화 여부가 조회조건이어서 if-else로 분기
+    Long indexInfoId = request.indexInfoId();
+    Boolean enabled = request.enabled();
+    Sort sort = createSort(request);
+
+    List<AutoSyncConfig> autoSyncConfigs;
+
+    if (indexInfoId == null && enabled == null) {
+      autoSyncConfigs = autoSyncConfigRepository.findAll(sort);
+    } else if (indexInfoId != null && enabled == null) {
+      autoSyncConfigs = autoSyncConfigRepository.findByIndexInfo_Id(indexInfoId, sort);
+    } else if (indexInfoId == null) {
+      autoSyncConfigs = autoSyncConfigRepository.findByEnabled(enabled, sort);
+    } else {
+      autoSyncConfigs = autoSyncConfigRepository.findByIndexInfo_IdAndEnabled(indexInfoId, enabled,
+          sort);
     }
 
-    public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
-        // 인덱스 ID와 활성화 여부가 조건, 이후 분기
-        Long indexInfoId = request.indexInfoId();
-        Boolean enabled = request.enabled();
+    List<AutoSyncConfigResponse> content = autoSyncConfigs.stream()
+        .map(this::toResponse)
+        .toList();
 
-        List<AutoSyncConfig> autoSyncConfigs;
+    return new AutoSyncConfigPageResponse( // 최종 응답 목록 반환
+        content,
+        null,
+        null,
+        content.size(),
+        (long) content.size(),
+        false
+    );
+  }
 
-        if (indexInfoId == null && enabled == null) {
-            autoSyncConfigs = autoSyncConfigRepository.findAll();
-        } else if (indexInfoId != null && enabled == null) {
-            autoSyncConfigs = autoSyncConfigRepository.findByIndexInfo_Id(indexInfoId);
-        } else if (indexInfoId == null) {
-            autoSyncConfigs = autoSyncConfigRepository.findByEnabled(enabled);
-        } else {
-            autoSyncConfigs = autoSyncConfigRepository.findByIndexInfo_IdAndEnabled(indexInfoId, enabled);
-        }
+  // 개별 데이터 DTO 변환
+  private AutoSyncConfigResponse toResponse(AutoSyncConfig autoSyncConfig) {
+    return new AutoSyncConfigResponse(
+        autoSyncConfig.getId(),
+        autoSyncConfig.getIndexInfo().getId(),
+        autoSyncConfig.getIndexInfo().getIndexClassification(),
+        autoSyncConfig.getIndexInfo().getIndexName(),
+        autoSyncConfig.getEnabled()
+    );
+  }
 
-        List<AutoSyncConfigResponse> content = autoSyncConfigs.stream()
-                .map(this::toResponse)
-                .toList();
+  // 2가지 조건이라 if-else로 정렬
+  private Sort createSort(AutoSyncConfigListRequest request) {
+    String sortField = request.sortField();
+    String sortDirection = request.sortDirection();
 
-        return new AutoSyncConfigPageResponse( // 최종 응답 목록 반환
-                content,
-                null,
-                null,
-                content.size(),
-                (long) content.size(),
-                false
-        );
+    String sortBy;
+    if ("enabled".equals(sortField)) {
+      sortBy = "enabled";
+    } else {
+      sortBy = "indexInfo.indexName";
     }
-    // 개별 데이터 DTO 변환
-    private AutoSyncConfigResponse toResponse(AutoSyncConfig autoSyncConfig) {
-        return new AutoSyncConfigResponse(
-                autoSyncConfig.getId(),
-                autoSyncConfig.getIndexInfo().getId(),
-                autoSyncConfig.getIndexInfo().getIndexClassification(),
-                autoSyncConfig.getIndexInfo().getIndexName(),
-                autoSyncConfig.getEnabled()
-        );
+
+    Sort.Direction direction;
+    if ("desc".equalsIgnoreCase(sortDirection)) {
+      direction = Sort.Direction.DESC;
+    } else {
+      direction = Sort.Direction.ASC;
     }
+
+    return Sort.by(direction, sortBy);
+  }
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/Service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/Service/AutoSyncConfigService.java
@@ -1,0 +1,48 @@
+package com.codeit.findex.domain.autosyncconfig.Service;
+
+import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigListRequest;
+import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
+import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigResponse;
+import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
+import com.codeit.findex.domain.autosyncconfig.repository.AutoSyncConfigRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AutoSyncConfigService {
+
+    private final AutoSyncConfigRepository autoSyncConfigRepository;
+
+    public AutoSyncConfigService(AutoSyncConfigRepository autoSyncConfigRepository) {
+        this.autoSyncConfigRepository = autoSyncConfigRepository;
+    }
+
+    public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
+        List<AutoSyncConfig> autoSyncConfigs = autoSyncConfigRepository.findAll();
+
+        List<AutoSyncConfigResponse> content = autoSyncConfigs.stream()
+                .map(this::toResponse)
+                .toList();
+
+        //페이지네이션 구현 이전 임시 응답 양식
+        return new AutoSyncConfigPageResponse(
+                content,
+                null,
+                null,
+                content.size(),
+                (long) content.size(),
+                false
+        );
+    }
+
+    private AutoSyncConfigResponse toResponse(AutoSyncConfig autoSyncConfig) {
+        return new AutoSyncConfigResponse(
+                autoSyncConfig.getId(),
+                autoSyncConfig.getIndexInfo().getId(),
+                autoSyncConfig.getIndexInfo().getIndexClassification(),
+                autoSyncConfig.getIndexInfo().getIndexName(),
+                autoSyncConfig.getEnabled()
+        );
+    }
+}

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/Service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/Service/AutoSyncConfigService.java
@@ -20,10 +20,13 @@ public class AutoSyncConfigService {
   }
 
   public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
-    // 인덱스 ID와 활성화 여부가 조회조건이어서 if-else로 분기
     Long indexInfoId = request.indexInfoId();
     Boolean enabled = request.enabled();
-    Sort sort = createSort(request);
+
+    Sort sort = createSort(request); // 정렬 조건
+
+    Integer requestSize = request.size();
+    int size = (requestSize == null || requestSize <= 0) ? 10 : requestSize;
 
     List<AutoSyncConfig> autoSyncConfigs;
 
@@ -38,21 +41,45 @@ public class AutoSyncConfigService {
           sort);
     }
 
-    List<AutoSyncConfigResponse> content = autoSyncConfigs.stream()
+    List<AutoSyncConfig> filteredItems = autoSyncConfigs.stream()
+        .filter(config -> isAfterCursor(config, request))
+        .toList(); // 커서 이후 필터링
+
+    boolean hasNext = filteredItems.size() > size;
+
+    List<AutoSyncConfig> pageItems = filteredItems.stream()
+        .limit(size)
+        .toList(); // 항목 추출
+
+    List<AutoSyncConfigResponse> content = pageItems.stream()
         .map(this::toResponse)
         .toList();
 
-    return new AutoSyncConfigPageResponse( // 최종 응답 목록 반환
+    String nextCursor = null;
+    Long nextIdAfter = null;
+
+    // 다음 페이지 커서 계산
+    if (hasNext && !pageItems.isEmpty()) {
+      AutoSyncConfig lastItem = pageItems.get(pageItems.size() - 1);
+      nextIdAfter = lastItem.getId();
+
+      if ("enabled".equals(request.sortField())) {
+        nextCursor = String.valueOf(lastItem.getEnabled());
+      } else {
+        nextCursor = lastItem.getIndexInfo().getIndexName();
+      }
+    }
+
+    return new AutoSyncConfigPageResponse(
         content,
-        null,
-        null,
+        nextCursor,
+        nextIdAfter,
         content.size(),
-        (long) content.size(),
-        false
+        (long) filteredItems.size(),
+        hasNext
     );
   }
 
-  // 개별 데이터 DTO 변환
   private AutoSyncConfigResponse toResponse(AutoSyncConfig autoSyncConfig) {
     return new AutoSyncConfigResponse(
         autoSyncConfig.getId(),
@@ -63,7 +90,6 @@ public class AutoSyncConfigService {
     );
   }
 
-  // 2가지 조건이라 if-else로 정렬
   private Sort createSort(AutoSyncConfigListRequest request) {
     String sortField = request.sortField();
     String sortDirection = request.sortDirection();
@@ -83,5 +109,28 @@ public class AutoSyncConfigService {
     }
 
     return Sort.by(direction, sortBy);
+  }
+
+  private boolean isAfterCursor(AutoSyncConfig config, AutoSyncConfigListRequest request) {
+    String cursor = request.cursor();
+    Long idAfter = request.idAfter();
+    String sortDirection = request.sortDirection();
+
+    if (cursor == null || idAfter == null) {
+      return true;
+    }
+
+    int compare;
+    if ("enabled".equals(request.sortField())) {
+      compare = config.getEnabled().compareTo(Boolean.valueOf(cursor));
+    } else {
+      compare = config.getIndexInfo().getIndexName().compareTo(cursor);
+    }
+
+    if ("desc".equalsIgnoreCase(sortDirection)) {
+      return compare < 0 || (compare == 0 && config.getId() > idAfter);
+    }
+
+    return compare > 0 || (compare == 0 && config.getId() > idAfter);
   }
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
@@ -1,8 +1,8 @@
 package com.codeit.findex.domain.autosyncconfig.controller;
 
-import com.codeit.findex.domain.autosyncconfig.Service.AutoSyncConfigService;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigListRequest;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
+import com.codeit.findex.domain.autosyncconfig.service.AutoSyncConfigService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,13 +11,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auto-sync-configs")
 public class AutoSyncConfigController {
 
-    private final AutoSyncConfigService autoSyncConfigService;
+  private final AutoSyncConfigService autoSyncConfigService;
 
-    public AutoSyncConfigController(AutoSyncConfigService autoSyncConfigService) {
-        this.autoSyncConfigService = autoSyncConfigService;
-    }
-    @GetMapping
-    public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request){
-        return autoSyncConfigService.getAutoSyncConfigs(request);
-    }
+  public AutoSyncConfigController(AutoSyncConfigService autoSyncConfigService) {
+    this.autoSyncConfigService = autoSyncConfigService;
+  }
+
+  @GetMapping
+  public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
+    return autoSyncConfigService.getAutoSyncConfigs(request);
+  }
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
@@ -3,22 +3,24 @@ package com.codeit.findex.domain.autosyncconfig.controller;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigListRequest;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
 import com.codeit.findex.domain.autosyncconfig.service.AutoSyncConfigService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/auto-sync-configs")
 public class AutoSyncConfigController {
 
   private final AutoSyncConfigService autoSyncConfigService;
 
-  public AutoSyncConfigController(AutoSyncConfigService autoSyncConfigService) {
-    this.autoSyncConfigService = autoSyncConfigService;
-  }
-
   @GetMapping
-  public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
-    return autoSyncConfigService.getAutoSyncConfigs(request);
+  public ResponseEntity<AutoSyncConfigPageResponse> getAutoSyncConfigs(
+      @Valid AutoSyncConfigListRequest request) {
+    AutoSyncConfigPageResponse response = autoSyncConfigService.getAutoSyncConfigs(request);
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
@@ -1,0 +1,23 @@
+package com.codeit.findex.domain.autosyncconfig.controller;
+
+import com.codeit.findex.domain.autosyncconfig.Service.AutoSyncConfigService;
+import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigListRequest;
+import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auto-sync-configs")
+public class AutoSyncConfigController {
+
+    private final AutoSyncConfigService autoSyncConfigService;
+
+    public AutoSyncConfigController(AutoSyncConfigService autoSyncConfigService) {
+        this.autoSyncConfigService = autoSyncConfigService;
+    }
+    @GetMapping
+    public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request){
+        return autoSyncConfigService.getAutoSyncConfigs(request);
+    }
+}

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigListRequest.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigListRequest.java
@@ -1,0 +1,12 @@
+package com.codeit.findex.domain.autosyncconfig.dto;
+
+public record AutoSyncConfigListRequest(
+        Long indexInfoId,
+        Boolean enabled,
+        Long idAfter,
+        String cursor,
+        String sortField,
+        String sortDirection,
+        Integer size
+) {
+}

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigListRequest.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigListRequest.java
@@ -1,12 +1,19 @@
 package com.codeit.findex.domain.autosyncconfig.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+
 public record AutoSyncConfigListRequest(
     Long indexInfoId,
     Boolean enabled,
     Long idAfter,
     String cursor,
+    @Pattern(regexp = "^(indexInfo.indexName|enabled)$")
     String sortField,
+    @Pattern(regexp = "^(asc|desc)$")
     String sortDirection,
+    @Min(1)
     Integer size
 ) {
+
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigListRequest.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigListRequest.java
@@ -1,12 +1,12 @@
 package com.codeit.findex.domain.autosyncconfig.dto;
 
 public record AutoSyncConfigListRequest(
-        Long indexInfoId,
-        Boolean enabled,
-        Long idAfter,
-        String cursor,
-        String sortField,
-        String sortDirection,
-        Integer size
+    Long indexInfoId,
+    Boolean enabled,
+    Long idAfter,
+    String cursor,
+    String sortField,
+    String sortDirection,
+    Integer size
 ) {
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigPageResponse.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigPageResponse.java
@@ -3,11 +3,11 @@ package com.codeit.findex.domain.autosyncconfig.dto;
 import java.util.List;
 
 public record AutoSyncConfigPageResponse(
-        List<AutoSyncConfigResponse> content,
-        String nextCursor,
-        Long nextIdAfter,
-        Integer size,
-        Long totalElements,
-        Boolean hasNext
+    List<AutoSyncConfigResponse> content,
+    String nextCursor,
+    Long nextIdAfter,
+    Integer size,
+    Long totalElements,
+    Boolean hasNext
 ) {
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigPageResponse.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigPageResponse.java
@@ -1,0 +1,13 @@
+package com.codeit.findex.domain.autosyncconfig.dto;
+
+import java.util.List;
+
+public record AutoSyncConfigPageResponse(
+        List<AutoSyncConfigResponse> content,
+        String nextCursor,
+        Long nextIdAfter,
+        Integer size,
+        Long totalElements,
+        Boolean hasNext
+) {
+}

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigResponse.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigResponse.java
@@ -1,0 +1,10 @@
+package com.codeit.findex.domain.autosyncconfig.dto;
+
+public record AutoSyncConfigResponse(
+        Long id,
+        Long indexInfoId,
+        String indexClassification,
+        String indexName,
+        Boolean enabled
+) {
+}

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigResponse.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigResponse.java
@@ -1,10 +1,10 @@
 package com.codeit.findex.domain.autosyncconfig.dto;
 
 public record AutoSyncConfigResponse(
-        Long id,
-        Long indexInfoId,
-        String indexClassification,
-        String indexName,
-        Boolean enabled
+    Long id,
+    Long indexInfoId,
+    String indexClassification,
+    String indexName,
+    Boolean enabled
 ) {
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/repository/AutoSyncConfigRepository.java
@@ -1,6 +1,7 @@
 package com.codeit.findex.domain.autosyncconfig.repository;
 
 import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,9 +10,8 @@ import java.util.List;
 @Repository
 public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, Long>
 {
-    List<AutoSyncConfig> findAll();
-    List<AutoSyncConfig> findByIndexInfo_Id(Long indexInfoId);
-    List<AutoSyncConfig> findByEnabled(Boolean enabled);
-    List<AutoSyncConfig> findByIndexInfo_IdAndEnabled(Long indexInfoId, Boolean enabled);
+    List<AutoSyncConfig> findByIndexInfo_Id(Long indexInfoId, Sort sort);
+    List<AutoSyncConfig> findByEnabled(Boolean enabled, Sort sort);
+    List<AutoSyncConfig> findByIndexInfo_IdAndEnabled(Long indexInfoId, Boolean enabled, Sort sort);
 
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/repository/AutoSyncConfigRepository.java
@@ -1,0 +1,10 @@
+package com.codeit.findex.domain.autosyncconfig.repository;
+
+import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, Long>
+{
+}

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/repository/AutoSyncConfigRepository.java
@@ -1,17 +1,16 @@
 package com.codeit.findex.domain.autosyncconfig.repository;
 
 import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
+import java.util.List;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
-public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, Long>
-{
-    List<AutoSyncConfig> findByIndexInfo_Id(Long indexInfoId, Sort sort);
-    List<AutoSyncConfig> findByEnabled(Boolean enabled, Sort sort);
-    List<AutoSyncConfig> findByIndexInfo_IdAndEnabled(Long indexInfoId, Boolean enabled, Sort sort);
+public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, Long> {
+  List<AutoSyncConfig> findByIndexInfo_Id(Long indexInfoId, Sort sort);
 
+  List<AutoSyncConfig> findByEnabled(Boolean enabled, Sort sort);
+
+  List<AutoSyncConfig> findByIndexInfo_IdAndEnabled(Long indexInfoId, Boolean enabled, Sort sort);
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/repository/AutoSyncConfigRepository.java
@@ -4,7 +4,14 @@ import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, Long>
 {
+    List<AutoSyncConfig> findAll();
+    List<AutoSyncConfig> findByIndexInfo_Id(Long indexInfoId);
+    List<AutoSyncConfig> findByEnabled(Boolean enabled);
+    List<AutoSyncConfig> findByIndexInfo_IdAndEnabled(Long indexInfoId, Boolean enabled);
+
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
@@ -35,24 +35,24 @@ public class AutoSyncConfigService {
       autoSyncConfigs = autoSyncConfigRepository.findByEnabled(enabled, sort);
     } else {
       autoSyncConfigs = autoSyncConfigRepository.findByIndexInfo_IdAndEnabled(
-        indexInfoId,
-        enabled,
-        sort
+          indexInfoId,
+          enabled,
+          sort
       );
     }
 
     List<AutoSyncConfig> filteredItems = autoSyncConfigs.stream()
-      .filter(config -> isAfterCursor(config, request))
-      .toList();
+        .filter(config -> isAfterCursor(config, request))
+        .toList();
 
     boolean hasNext = filteredItems.size() > size;
     List<AutoSyncConfig> pageItems = filteredItems.stream()
-      .limit(size)
-      .toList();
+        .limit(size)
+        .toList();
 
     List<AutoSyncConfigResponse> content = pageItems.stream()
-      .map(this::toResponse)
-      .toList();
+        .map(this::toResponse)
+        .toList();
 
     String nextCursor = null;
     Long nextIdAfter = null;
@@ -68,22 +68,22 @@ public class AutoSyncConfigService {
     }
 
     return new AutoSyncConfigPageResponse(
-      content,
-      nextCursor,
-      nextIdAfter,
-      content.size(),
-      (long) filteredItems.size(),
-      hasNext
+        content,
+        nextCursor,
+        nextIdAfter,
+        content.size(),
+        (long) filteredItems.size(),
+        hasNext
     );
   }
 
   private AutoSyncConfigResponse toResponse(AutoSyncConfig autoSyncConfig) {
     return new AutoSyncConfigResponse(
-      autoSyncConfig.getId(),
-      autoSyncConfig.getIndexInfo().getId(),
-      autoSyncConfig.getIndexInfo().getIndexClassification(),
-      autoSyncConfig.getIndexInfo().getIndexName(),
-      autoSyncConfig.getEnabled()
+        autoSyncConfig.getId(),
+        autoSyncConfig.getIndexInfo().getId(),
+        autoSyncConfig.getIndexInfo().getIndexClassification(),
+        autoSyncConfig.getIndexInfo().getIndexName(),
+        autoSyncConfig.getEnabled()
     );
   }
 

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
@@ -1,4 +1,4 @@
-package com.codeit.findex.domain.autosyncconfig.Service;
+package com.codeit.findex.domain.autosyncconfig.service;
 
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigListRequest;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
@@ -8,7 +8,6 @@ import com.codeit.findex.domain.autosyncconfig.repository.AutoSyncConfigReposito
 import java.util.List;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-
 
 @Service
 public class AutoSyncConfigService {
@@ -22,14 +21,12 @@ public class AutoSyncConfigService {
   public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
     Long indexInfoId = request.indexInfoId();
     Boolean enabled = request.enabled();
-
-    Sort sort = createSort(request); // 정렬 조건
+    Sort sort = createSort(request);
 
     Integer requestSize = request.size();
     int size = (requestSize == null || requestSize <= 0) ? 10 : requestSize;
 
     List<AutoSyncConfig> autoSyncConfigs;
-
     if (indexInfoId == null && enabled == null) {
       autoSyncConfigs = autoSyncConfigRepository.findAll(sort);
     } else if (indexInfoId != null && enabled == null) {
@@ -37,28 +34,28 @@ public class AutoSyncConfigService {
     } else if (indexInfoId == null) {
       autoSyncConfigs = autoSyncConfigRepository.findByEnabled(enabled, sort);
     } else {
-      autoSyncConfigs = autoSyncConfigRepository.findByIndexInfo_IdAndEnabled(indexInfoId, enabled,
-          sort);
+      autoSyncConfigs = autoSyncConfigRepository.findByIndexInfo_IdAndEnabled(
+        indexInfoId,
+        enabled,
+        sort
+      );
     }
 
     List<AutoSyncConfig> filteredItems = autoSyncConfigs.stream()
-        .filter(config -> isAfterCursor(config, request))
-        .toList(); // 커서 이후 필터링
+      .filter(config -> isAfterCursor(config, request))
+      .toList();
 
     boolean hasNext = filteredItems.size() > size;
-
     List<AutoSyncConfig> pageItems = filteredItems.stream()
-        .limit(size)
-        .toList(); // 항목 추출
+      .limit(size)
+      .toList();
 
     List<AutoSyncConfigResponse> content = pageItems.stream()
-        .map(this::toResponse)
-        .toList();
+      .map(this::toResponse)
+      .toList();
 
     String nextCursor = null;
     Long nextIdAfter = null;
-
-    // 다음 페이지 커서 계산
     if (hasNext && !pageItems.isEmpty()) {
       AutoSyncConfig lastItem = pageItems.get(pageItems.size() - 1);
       nextIdAfter = lastItem.getId();
@@ -71,22 +68,22 @@ public class AutoSyncConfigService {
     }
 
     return new AutoSyncConfigPageResponse(
-        content,
-        nextCursor,
-        nextIdAfter,
-        content.size(),
-        (long) filteredItems.size(),
-        hasNext
+      content,
+      nextCursor,
+      nextIdAfter,
+      content.size(),
+      (long) filteredItems.size(),
+      hasNext
     );
   }
 
   private AutoSyncConfigResponse toResponse(AutoSyncConfig autoSyncConfig) {
     return new AutoSyncConfigResponse(
-        autoSyncConfig.getId(),
-        autoSyncConfig.getIndexInfo().getId(),
-        autoSyncConfig.getIndexInfo().getIndexClassification(),
-        autoSyncConfig.getIndexInfo().getIndexName(),
-        autoSyncConfig.getEnabled()
+      autoSyncConfig.getId(),
+      autoSyncConfig.getIndexInfo().getId(),
+      autoSyncConfig.getIndexInfo().getIndexClassification(),
+      autoSyncConfig.getIndexInfo().getIndexName(),
+      autoSyncConfig.getEnabled()
     );
   }
 


### PR DESCRIPTION
## 작업 내용
자동 연동 설정 목록 조회 API 구현 및 테스트

## 변경 사항
- 자동 연동 설정 목록 조회 엔드포인트 구현
- 필터 조건 추가
- 정렬 기능 추가
- 커서 기반 페이지네이션 구현
- 로컬 테스트 데이터로 추가한 기능 및 구현 내용 모두 정상 작동하고 있는 것 확인 완료했습니다

## 테스트
- [x] 로컬 테스트 여부
- [x] 컨벤션 부합 여부

## 🔍 코드리뷰 요청 사항

### 요청 1
- **파일/위치**: `src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java`
- **요청 내용**:
  > Line 30부터 시작하는 분기 처리에 대해 더 나은 방식이 있을지 궁금합니다
- **고민한 점**:
  > 조건이 2개 뿐이어서 if문을 일일히 사용해 처리했는데, 코드 일관성을 위해서 쿼리 고도화 전략을 사용하는 것이 좋은지 생각해보았지만 코드가 크게 복잡해지지 않는다고 판단해서 해당 방식으로 작성했습니다. 이러한 경우에서 어떻게 처리하는 것이 전체 관점에서 바람직한지 잘 모르겠습니다


Closes #5