### PR TITLE
feat: 자동 연동 설정 수정

### DIFF
--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
@@ -5,6 +5,10 @@ import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigResponse;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigUpdateRequest;
 import com.codeit.findex.domain.autosyncconfig.service.AutoSyncConfigService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "자동 연동 설정 API", description = "자동 연동 설정 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auto-sync-configs")
@@ -22,6 +27,12 @@ public class AutoSyncConfigController {
 
   private final AutoSyncConfigService autoSyncConfigService;
 
+  @Operation(summary = "자동 연동 설정 목록 조회", description = "자동 연동 설정 목록을 조회합니다. 필터링, 정렬, 커서 기반 페이지네이션을 지원합니다.", operationId = "getAutoSyncConfigList")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "자동 연동 설정 목록 조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필터 값 등)"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
   @GetMapping
   public ResponseEntity<AutoSyncConfigPageResponse> getAutoSyncConfigs(
       @Valid AutoSyncConfigListRequest request) {
@@ -29,6 +40,13 @@ public class AutoSyncConfigController {
     return ResponseEntity.ok(response);
   }
 
+  @Operation(summary = "자동 연동 설정 수정", description = "기존 자동 연동 설정을 수정합니다.", operationId = "updateAutoSyncConfig")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "자동 연동 설정 수정 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 설정 값 등)"),
+      @ApiResponse(responseCode = "404", description = "수정할 자동 연동 설정을 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
   @PatchMapping("/{id}")
   public ResponseEntity<AutoSyncConfigResponse> updateAutoSyncConfig(
       @PathVariable Long id,

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
@@ -2,11 +2,16 @@ package com.codeit.findex.domain.autosyncconfig.controller;
 
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigListRequest;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
+import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigResponse;
+import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigUpdateRequest;
 import com.codeit.findex.domain.autosyncconfig.service.AutoSyncConfigService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,6 +26,16 @@ public class AutoSyncConfigController {
   public ResponseEntity<AutoSyncConfigPageResponse> getAutoSyncConfigs(
       @Valid AutoSyncConfigListRequest request) {
     AutoSyncConfigPageResponse response = autoSyncConfigService.getAutoSyncConfigs(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<AutoSyncConfigResponse> updateAutoSyncConfig(
+      @PathVariable Long id,
+      @RequestBody @Valid AutoSyncConfigUpdateRequest request
+  ) {
+    AutoSyncConfigResponse response =
+        autoSyncConfigService.updateAutoSyncConfig(id, request);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigMapper.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigMapper.java
@@ -1,0 +1,15 @@
+package com.codeit.findex.domain.autosyncconfig.dto;
+
+import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface AutoSyncConfigMapper {
+
+  @Mapping(source = "indexInfo.id", target = "indexInfoId")
+  @Mapping(source = "indexInfo.indexClassification", target = "indexClassification")
+  @Mapping(source = "indexInfo.indexName", target = "indexName")
+  AutoSyncConfigResponse toAutoSyncConfigResponse(AutoSyncConfig autoSyncConfig);
+}

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigUpdateRequest.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.codeit.findex.domain.autosyncconfig.dto;
+
+public record AutoSyncConfigUpdateRequest(
+    boolean enabled
+) {
+
+}

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigUpdateRequest.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigUpdateRequest.java
@@ -1,7 +1,10 @@
 package com.codeit.findex.domain.autosyncconfig.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public record AutoSyncConfigUpdateRequest(
-    boolean enabled
+    @NotNull
+    Boolean enabled
 ) {
 
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigUpdateRequest.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigUpdateRequest.java
@@ -3,7 +3,7 @@ package com.codeit.findex.domain.autosyncconfig.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record AutoSyncConfigUpdateRequest(
-    @NotNull
+    @NotNull(message = "활성화 여부는 필수입니다.")
     Boolean enabled
 ) {
 

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/entity/AutoSyncConfig.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/entity/AutoSyncConfig.java
@@ -33,4 +33,8 @@ public class AutoSyncConfig {
   public static AutoSyncConfig create(IndexInfo indexInfo, Boolean enabled) {
     return new AutoSyncConfig(indexInfo, enabled);
   }
+
+  public void updateEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
@@ -3,12 +3,14 @@ package com.codeit.findex.domain.autosyncconfig.service;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigListRequest;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigResponse;
+import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigUpdateRequest;
 import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
 import com.codeit.findex.domain.autosyncconfig.repository.AutoSyncConfigRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -127,5 +129,14 @@ public class AutoSyncConfigService {
     }
 
     return compare > 0 || (compare == 0 && config.getId() > idAfter);
+  }
+
+  @Transactional
+  public AutoSyncConfigResponse updateAutoSyncConfig(Long id, AutoSyncConfigUpdateRequest request) {
+    AutoSyncConfig autoSyncConfig = autoSyncConfigRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("자동 연동 설정을 찾을 수 없습니다."));
+
+    autoSyncConfig.updateEnabled(request.enabled());
+    return toAutoSyncConfigResponse(autoSyncConfig);
   }
 }

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
@@ -6,17 +6,15 @@ import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigResponse;
 import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
 import com.codeit.findex.domain.autosyncconfig.repository.AutoSyncConfigRepository;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class AutoSyncConfigService {
 
   private final AutoSyncConfigRepository autoSyncConfigRepository;
-
-  public AutoSyncConfigService(AutoSyncConfigRepository autoSyncConfigRepository) {
-    this.autoSyncConfigRepository = autoSyncConfigRepository;
-  }
 
   public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
     Long indexInfoId = request.indexInfoId();
@@ -51,7 +49,7 @@ public class AutoSyncConfigService {
         .toList();
 
     List<AutoSyncConfigResponse> content = pageItems.stream()
-        .map(this::toResponse)
+        .map(this::toAutoSyncConfigResponse)
         .toList();
 
     String nextCursor = null;
@@ -77,7 +75,7 @@ public class AutoSyncConfigService {
     );
   }
 
-  private AutoSyncConfigResponse toResponse(AutoSyncConfig autoSyncConfig) {
+  private AutoSyncConfigResponse toAutoSyncConfigResponse(AutoSyncConfig autoSyncConfig) {
     return new AutoSyncConfigResponse(
         autoSyncConfig.getId(),
         autoSyncConfig.getIndexInfo().getId(),

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
@@ -6,6 +6,7 @@ import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigResponse;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigUpdateRequest;
 import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
 import com.codeit.findex.domain.autosyncconfig.repository.AutoSyncConfigRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -134,7 +135,7 @@ public class AutoSyncConfigService {
   @Transactional
   public AutoSyncConfigResponse updateAutoSyncConfig(Long id, AutoSyncConfigUpdateRequest request) {
     AutoSyncConfig autoSyncConfig = autoSyncConfigRepository.findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("자동 연동 설정을 찾을 수 없습니다."));
+        .orElseThrow(() -> new EntityNotFoundException("자동 연동 설정을 찾을 수 없습니다."));
 
     autoSyncConfig.updateEnabled(request.enabled());
     return toAutoSyncConfigResponse(autoSyncConfig);

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
@@ -51,7 +51,7 @@ public class AutoSyncConfigService {
         .toList();
 
     List<AutoSyncConfigResponse> content = pageItems.stream()
-        .map(this::toResponse)
+        .map(this::toAutoSyncConfigResponse)
         .toList();
 
     String nextCursor = null;
@@ -77,7 +77,7 @@ public class AutoSyncConfigService {
     );
   }
 
-  private AutoSyncConfigResponse toResponse(AutoSyncConfig autoSyncConfig) {
+  private AutoSyncConfigResponse toAutoSyncConfigResponse(AutoSyncConfig autoSyncConfig) {
     return new AutoSyncConfigResponse(
         autoSyncConfig.getId(),
         autoSyncConfig.getIndexInfo().getId(),

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/service/AutoSyncConfigService.java
@@ -1,6 +1,7 @@
 package com.codeit.findex.domain.autosyncconfig.service;
 
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigListRequest;
+import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigMapper;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigResponse;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigUpdateRequest;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AutoSyncConfigService {
 
   private final AutoSyncConfigRepository autoSyncConfigRepository;
+  private final AutoSyncConfigMapper autoSyncConfigMapper;
 
   public AutoSyncConfigPageResponse getAutoSyncConfigs(AutoSyncConfigListRequest request) {
     Long indexInfoId = request.indexInfoId();
@@ -52,7 +54,7 @@ public class AutoSyncConfigService {
         .toList();
 
     List<AutoSyncConfigResponse> content = pageItems.stream()
-        .map(this::toAutoSyncConfigResponse)
+        .map(autoSyncConfigMapper::toAutoSyncConfigResponse)
         .toList();
 
     String nextCursor = null;
@@ -75,16 +77,6 @@ public class AutoSyncConfigService {
         content.size(),
         (long) filteredItems.size(),
         hasNext
-    );
-  }
-
-  private AutoSyncConfigResponse toAutoSyncConfigResponse(AutoSyncConfig autoSyncConfig) {
-    return new AutoSyncConfigResponse(
-        autoSyncConfig.getId(),
-        autoSyncConfig.getIndexInfo().getId(),
-        autoSyncConfig.getIndexInfo().getIndexClassification(),
-        autoSyncConfig.getIndexInfo().getIndexName(),
-        autoSyncConfig.getEnabled()
     );
   }
 
@@ -138,6 +130,6 @@ public class AutoSyncConfigService {
         .orElseThrow(() -> new EntityNotFoundException("자동 연동 설정을 찾을 수 없습니다."));
 
     autoSyncConfig.updateEnabled(request.enabled());
-    return toAutoSyncConfigResponse(autoSyncConfig);
+    return autoSyncConfigMapper.toAutoSyncConfigResponse(autoSyncConfig);
   }
 }

--- a/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.codeit.findex.global.error;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -23,11 +24,12 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(EntityNotFoundException.class)
   public ResponseEntity<ErrorResponse> handlerEntityNotFoundException(EntityNotFoundException e) {
-    ErrorResponse response = ErrorResponse.builder()
-        .status(HttpStatus.NOT_FOUND.value())
-        .message("데이터를 찾을 수 없습니다.")
-        .details(e.getMessage())
-        .build();
+    ErrorResponse response =
+        ErrorResponse.builder()
+            .status(HttpStatus.NOT_FOUND.value())
+            .message("데이터를 찾을 수 없습니다.")
+            .details(e.getMessage())
+            .build();
 
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
@@ -42,5 +44,24 @@ public class GlobalExceptionHandler {
             .build();
 
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handlerMethodArgumentNotValidException(
+      MethodArgumentNotValidException e) {
+    String details =
+        e.getBindingResult().getFieldErrors().stream()
+            .findFirst()
+            .map(error -> error.getField() + ": " + error.getDefaultMessage())
+            .orElse("요청값이 올바르지 않습니다.");
+
+    ErrorResponse response =
+        ErrorResponse.builder()
+            .status(HttpStatus.BAD_REQUEST.value())
+            .message("잘못된 요청입니다.")
+            .details(details)
+            .build();
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
   }
 }


### PR DESCRIPTION
## 작업 내용
자동 연동 설정 수정 API 구현, 관련 검증/예외 처리 및 응답 문서화
이전 PR에서 리뷰 받은 사항 반영해봤습니다.

## 변경 사항
- 수정 API 구현
- 수정 요청 DTO 추가
- 자동 연동 설정 수정 서비스 로직 구현
## 추가 변경 사항
- 존재하지 않는 자동 연동 설정 조회 시 예외 처리 보강
- 수정 요청값 validation 보강
- Mapper 도입
- 자동 연동 설정 조회/수정 API Swagger 응답 명세 추가
- validation 예외에 대한 400 응답 처리 추가

## 테스트
- [x] 로컬 테스트 여부
- H2 테스트 데이터 기준 수정 API 정상 응답 확인
- 수정 후 DB 값 반영 확인
- 존재하지 않는 id 요청 시 예외 응답 확인
- validation 실패시 예외 응답 확인
- [x] 컨벤션 부합 여부

Closes #16 