### PR TITLE
feat: 지수 정보 수정

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
@@ -1,7 +1,8 @@
 package com.codeit.findex.domain.indexinfo.controller;
 
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateResponse;
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoResponse;
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.codeit.findex.domain.indexinfo.service.IndexInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,10 +29,24 @@ public class IndexInfoController {
   private final IndexInfoService indexInfoService;
 
   @PostMapping
-  public ResponseEntity<IndexInfoCreateResponse> createIndexInfo(
+  public ResponseEntity<IndexInfoResponse> createIndexInfo(
       @Valid @RequestBody IndexInfoCreateRequest request) {
-    IndexInfoCreateResponse response = indexInfoService.createIndexInfo(request);
+    IndexInfoResponse response = indexInfoService.createIndexInfo(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @Operation(summary = "지수 정보 수정", description = "기존 지수 정보를 수정합니다.", operationId = "updateIndexInfo")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필드 값 등)"),
+      @ApiResponse(responseCode = "404", description = "수정할 지수 정보를 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류"),
+      @ApiResponse(responseCode = "200", description = "지수 정보 수정 성공")
+  })
+  @PatchMapping("/{id}")
+  public ResponseEntity<IndexInfoResponse> updateIndexInfo(@PathVariable Long id,
+      @Valid @RequestBody IndexInfoUpdateRequest request) {
+    IndexInfoResponse response = indexInfoService.updateIndexInfo(id, request);
+    return ResponseEntity.ok(response);
   }
 
   @Operation(summary = "지수 정보 삭제", description = "지수 정보를 삭제합니다. 관련된 지수 데이터도 함께 삭제됩니다.", operationId = "deleteIndexInfo")

--- a/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoMapper.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoMapper.java
@@ -8,5 +8,5 @@ import org.mapstruct.ReportingPolicy;
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface IndexInfoMapper {
 
-  IndexInfoCreateResponse toIndexInfoCreateResponse(IndexInfo indexInfo);
+  IndexInfoResponse toIndexInfoCreateResponse(IndexInfo indexInfo);
 }

--- a/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoResponse.java
@@ -5,7 +5,7 @@ import com.codeit.findex.domain.common.enums.SourceType;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-public record IndexInfoCreateResponse(
+public record IndexInfoResponse(
     Long id,
     String indexClassification,
     String indexName,
@@ -14,7 +14,7 @@ public record IndexInfoCreateResponse(
     BigDecimal baseIndex,
     SourceType sourceType,
     Boolean favorite) {
-  public static IndexInfoCreateResponse create(
+  public static IndexInfoResponse create(
       Long id,
       String indexClassification,
       String indexName,
@@ -23,7 +23,7 @@ public record IndexInfoCreateResponse(
       BigDecimal baseIndex,
       SourceType sourceType,
       Boolean favorite) {
-    return new IndexInfoCreateResponse(
+    return new IndexInfoResponse(
         id,
         indexClassification,
         indexName,

--- a/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoUpdateRequest.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.codeit.findex.domain.indexinfo.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record IndexInfoUpdateRequest(
+    @NotNull(message = "채용 종목 수는 필수입니다.")
+    @PositiveOrZero(message = "채용 종목 수는 음수일 수 없습니다.")
+    Integer employedItemsCount,
+
+    @NotNull(message = "기준 시점은 필수입니다.")
+    LocalDate basePointInTime,
+
+    @NotNull(message = "기준 지수는 필수입니다.")
+    BigDecimal baseIndex,
+
+    // null이면 false로 지정됨
+    Boolean favorite
+) {
+
+}

--- a/src/main/java/com/codeit/findex/domain/indexinfo/entity/IndexInfo.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/entity/IndexInfo.java
@@ -106,4 +106,11 @@ public class IndexInfo {
         SourceType.USER,
         favorite);
   }
+
+  public void update(Integer employedItemsCount, LocalDate basePointInTime, BigDecimal baseIndex, Boolean favorite) {
+    this.employedItemsCount = employedItemsCount;
+    this.basePointInTime = basePointInTime;
+    this.baseIndex = baseIndex;
+    this.favorite = favorite != null ? favorite : false;
+  }
 }

--- a/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
@@ -1,8 +1,9 @@
 package com.codeit.findex.domain.indexinfo.service;
 
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateResponse;
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoResponse;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoMapper;
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
 import com.codeit.findex.domain.indexinfo.repository.IndexInfoRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -19,7 +20,7 @@ public class IndexInfoService {
   private final IndexInfoMapper indexInfoMapper;
 
   @Transactional
-  public IndexInfoCreateResponse createIndexInfo(IndexInfoCreateRequest request) {
+  public IndexInfoResponse createIndexInfo(IndexInfoCreateRequest request) {
 
     // 1. 중복 검증 로직
     if (indexInfoRepository.existsByIndexClassificationAndIndexName(
@@ -41,6 +42,16 @@ public class IndexInfoService {
     IndexInfo savedIndexInfo = indexInfoRepository.save(newIndexInfo);
 
     return indexInfoMapper.toIndexInfoCreateResponse(savedIndexInfo);
+  }
+
+  @Transactional
+  public IndexInfoResponse updateIndexInfo(Long id, IndexInfoUpdateRequest request) {
+    IndexInfo indexInfo = indexInfoRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException("지수 정보를 찾을 수 없습니다 ID: " + id));
+
+    indexInfo.update(request.employedItemsCount(), request.basePointInTime(), request.baseIndex(), request.favorite());
+
+    return indexInfoMapper.toIndexInfoCreateResponse(indexInfo);
   }
 
   @Transactional

--- a/src/test/java/com/codeit/findex/domain/indexinfo/service/IndexInfoServiceTest.java
+++ b/src/test/java/com/codeit/findex/domain/indexinfo/service/IndexInfoServiceTest.java
@@ -1,7 +1,7 @@
 package com.codeit.findex.domain.indexinfo.service;
 
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateResponse;
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +26,7 @@ class IndexInfoServiceTest {
             "KOSPI시리즈", "IT 서비스", 200, LocalDate.of(2023, 1, 1), new BigDecimal("1000.00"), false);
 
     // when
-    IndexInfoCreateResponse indexInfo = indexInfoService.createIndexInfo(request);
+    IndexInfoResponse indexInfo = indexInfoService.createIndexInfo(request);
 
     // then
     assertThat(indexInfo.id()).isNotNull();

--- a/src/test/java/com/codeit/findex/domain/indexinfo/service/IndexInfoServiceTest.java
+++ b/src/test/java/com/codeit/findex/domain/indexinfo/service/IndexInfoServiceTest.java
@@ -2,6 +2,10 @@ package com.codeit.findex.domain.indexinfo.service;
 
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoResponse;
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
+import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
+import com.codeit.findex.domain.indexinfo.repository.IndexInfoRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +19,9 @@ import static org.assertj.core.api.Assertions.*;
 @Transactional
 class IndexInfoServiceTest {
 
+  @Autowired IndexInfoRepository indexInfoRepository;
   @Autowired IndexInfoService indexInfoService;
+  @Autowired EntityManager em;
 
   @Test
   @DisplayName("지수 정보를 실제 DB에 저장하고 조회할 수 있다.")
@@ -51,5 +57,28 @@ class IndexInfoServiceTest {
     assertThatThrownBy(() -> indexInfoService.createIndexInfo(request2))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("이미 동일한 지수 분류명과 지수명이 존재합니다.");
+  }
+
+  @Test
+  @DisplayName("지수 정보를 수정할 수 있다.")
+  void updateIndexInfo() {
+    // given
+    IndexInfo dummy = IndexInfo.createByUser("KOSPI시리즈", "IT 서비스", 200, LocalDate.of(2023, 1, 1), new BigDecimal("1000.00"), false);
+    IndexInfo savedInfo = indexInfoRepository.save(dummy);
+
+    // when
+    IndexInfoUpdateRequest updateRequest = new IndexInfoUpdateRequest(300, LocalDate.of(2024, 1, 1), new BigDecimal("2000.00"), true);
+    indexInfoService.updateIndexInfo(savedInfo.getId(), updateRequest);
+
+    em.flush(); // 서비스에서 변경된 내용을 DB로 보냄
+    em.clear(); // 메모리를 비워서 DB에서 객체를 가져오도록 함
+
+    // then
+    savedInfo = indexInfoRepository.findById(savedInfo.getId()).orElseThrow();
+
+    assertThat(savedInfo.getEmployedItemsCount()).isEqualTo(300);
+    assertThat(savedInfo.getBasePointInTime()).isEqualTo(LocalDate.of(2024, 1, 1));
+    assertThat(savedInfo.getBaseIndex()).isEqualByComparingTo(new BigDecimal("2000.00")); // 소수점까지 비교 가능
+    assertThat(savedInfo.getFavorite()).isTrue();
   }
 }


### PR DESCRIPTION
## 작업 내용
지수 정보를 수정할 수 있도록 비즈니스 로직, 엔드포인트 및 테스트 코드를 작성했습니다.


## 변경 사항
- **Entity**: `IndexInfo` 엔티티 내부에 데이터 수정을 위한 `update` 메서드 추가
- **API 구현**: 지수 정보 수정을 위한 `Controller`, `Service` 계층 로직 작성
- **DTO 리팩토링**: `updateIndexInfo` 메서드에서도 기존 생성 응답 DTO를 재사용함에 따라, `IndexInfoCreateResponse`를 범용적인 `IndexInfoResponse`로 이름 변경
- **테스트 코드**: `IndexInfoServiceTest`에 수정 기능 검증을 위한 `updateIndexInfo` 단위 테스트 추가

## 테스트
- [x] 로컬 테스트 여부
<img width="776" height="1032" alt="image" src="https://github.com/user-attachments/assets/3339a4fa-c5c1-4474-82c4-ca2cd7d74bc5" />

- [x] 컨벤션 부합 여부


Closes #17 