### PR TITLE
feat: 지수 정보 조회 API 구현 및 코드 리팩토링

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
@@ -12,13 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "지수 정보 API", description = "지수 정보 관리 API")
 @RestController
@@ -28,6 +22,16 @@ public class IndexInfoController {
 
   private final IndexInfoService indexInfoService;
 
+  @Operation(
+      summary = "지수 정보 등록",
+      description = "새로운 지수 정보를 등록합니다.",
+      operationId = "createIndexInfo")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "201", description = "지수 정보 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (필수 필드 누락 등)"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+      })
   @PostMapping
   public ResponseEntity<IndexInfoResponse> createIndexInfo(
       @Valid @RequestBody IndexInfoCreateRequest request) {
@@ -35,26 +39,50 @@ public class IndexInfoController {
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
-  @Operation(summary = "지수 정보 수정", description = "기존 지수 정보를 수정합니다.", operationId = "updateIndexInfo")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필드 값 등)"),
-      @ApiResponse(responseCode = "404", description = "수정할 지수 정보를 찾을 수 없음"),
-      @ApiResponse(responseCode = "500", description = "서버 오류"),
-      @ApiResponse(responseCode = "200", description = "지수 정보 수정 성공")
-  })
+  @Operation(
+      summary = "지수 정보 조회",
+      description = "ID로 지수 정보를 조회합니다.",
+      operationId = "readIndexInfoById")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "지수 정보 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "조회할 지수 정보를 찾을 수 없음"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+      })
+  @GetMapping("/{id}")
+  public ResponseEntity<IndexInfoResponse> readIndexInfoById(@PathVariable Long id) {
+    IndexInfoResponse response = indexInfoService.readIndexInfoById(id);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(
+      summary = "지수 정보 수정",
+      description = "기존 지수 정보를 수정합니다.",
+      operationId = "updateIndexInfo")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필드 값 등)"),
+        @ApiResponse(responseCode = "404", description = "수정할 지수 정보를 찾을 수 없음"),
+        @ApiResponse(responseCode = "500", description = "서버 오류"),
+        @ApiResponse(responseCode = "200", description = "지수 정보 수정 성공")
+      })
   @PatchMapping("/{id}")
-  public ResponseEntity<IndexInfoResponse> updateIndexInfo(@PathVariable Long id,
-      @Valid @RequestBody IndexInfoUpdateRequest request) {
+  public ResponseEntity<IndexInfoResponse> updateIndexInfo(
+      @PathVariable Long id, @Valid @RequestBody IndexInfoUpdateRequest request) {
     IndexInfoResponse response = indexInfoService.updateIndexInfo(id, request);
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "지수 정보 삭제", description = "지수 정보를 삭제합니다. 관련된 지수 데이터도 함께 삭제됩니다.", operationId = "deleteIndexInfo")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "404", description = "삭제할 지수 정보를 찾을 수 없음"),
-      @ApiResponse(responseCode = "500", description = "서버 오류"),
-      @ApiResponse(responseCode = "204", description = "지수 정보 삭제 성공")
-  })
+  @Operation(
+      summary = "지수 정보 삭제",
+      description = "지수 정보를 삭제합니다. 관련된 지수 데이터도 함께 삭제됩니다.",
+      operationId = "deleteIndexInfo")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "404", description = "삭제할 지수 정보를 찾을 수 없음"),
+        @ApiResponse(responseCode = "500", description = "서버 오류"),
+        @ApiResponse(responseCode = "204", description = "지수 정보 삭제 성공")
+      })
   @DeleteMapping("/{id}")
   public ResponseEntity<Void> deleteIndexInfo(@PathVariable Long id) {
     indexInfoService.deleteIndexInfo(id);

--- a/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoCreateRequest.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoCreateRequest.java
@@ -12,10 +12,4 @@ public record IndexInfoCreateRequest(
     @NotNull(message = "채용 종목 수는 필수입니다.") Integer employedItemsCount,
     @NotNull(message = "기준 시점은 필수입니다.") LocalDate basePointInTime,
     @NotNull(message = "기준 지수는 필수입니다.") BigDecimal baseIndex,
-    Boolean favorite) {
-  public IndexInfoCreateRequest {
-    if (favorite == null) {
-      favorite = false;
-    }
-  }
-}
+    Boolean favorite) {}

--- a/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoMapper.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoMapper.java
@@ -8,5 +8,5 @@ import org.mapstruct.ReportingPolicy;
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface IndexInfoMapper {
 
-  IndexInfoResponse toIndexInfoCreateResponse(IndexInfo indexInfo);
+  IndexInfoResponse toIndexInfoResponse(IndexInfo indexInfo);
 }

--- a/src/main/java/com/codeit/findex/domain/indexinfo/entity/IndexInfo.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/entity/IndexInfo.java
@@ -97,6 +97,7 @@ public class IndexInfo {
       LocalDate basePointInTime,
       BigDecimal baseIndex,
       Boolean favorite) {
+    favorite = favorite != null && favorite;
     return new IndexInfo(
         indexClassification,
         indexName,
@@ -107,7 +108,11 @@ public class IndexInfo {
         favorite);
   }
 
-  public void update(Integer employedItemsCount, LocalDate basePointInTime, BigDecimal baseIndex, Boolean favorite) {
+  public void update(
+      Integer employedItemsCount,
+      LocalDate basePointInTime,
+      BigDecimal baseIndex,
+      Boolean favorite) {
     this.employedItemsCount = employedItemsCount;
     this.basePointInTime = basePointInTime;
     this.baseIndex = baseIndex;

--- a/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
@@ -41,23 +41,39 @@ public class IndexInfoService {
     // 3. DB 저장
     IndexInfo savedIndexInfo = indexInfoRepository.save(newIndexInfo);
 
-    return indexInfoMapper.toIndexInfoCreateResponse(savedIndexInfo);
+    return indexInfoMapper.toIndexInfoResponse(savedIndexInfo);
+  }
+
+  public IndexInfoResponse readIndexInfoById(Long id) {
+    IndexInfo indexInfo =
+        indexInfoRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("지수 정보를 찾을 수 없습니다 ID: " + id));
+    return indexInfoMapper.toIndexInfoResponse(indexInfo);
   }
 
   @Transactional
   public IndexInfoResponse updateIndexInfo(Long id, IndexInfoUpdateRequest request) {
-    IndexInfo indexInfo = indexInfoRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException("지수 정보를 찾을 수 없습니다 ID: " + id));
+    IndexInfo indexInfo =
+        indexInfoRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("지수 정보를 찾을 수 없습니다 ID: " + id));
 
-    indexInfo.update(request.employedItemsCount(), request.basePointInTime(), request.baseIndex(), request.favorite());
+    indexInfo.update(
+        request.employedItemsCount(),
+        request.basePointInTime(),
+        request.baseIndex(),
+        request.favorite());
 
-    return indexInfoMapper.toIndexInfoCreateResponse(indexInfo);
+    return indexInfoMapper.toIndexInfoResponse(indexInfo);
   }
 
   @Transactional
   public void deleteIndexInfo(Long id) {
-    IndexInfo indexInfo = indexInfoRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException("지수 정보를 찾을 수 없습니다. ID: " + id));
+    IndexInfo indexInfo =
+        indexInfoRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("지수 정보를 찾을 수 없습니다. ID: " + id));
 
     indexInfoRepository.delete(indexInfo);
   }

--- a/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
@@ -23,11 +23,12 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(EntityNotFoundException.class)
   public ResponseEntity<ErrorResponse> handlerEntityNotFoundException(EntityNotFoundException e) {
-    ErrorResponse response = ErrorResponse.builder()
-        .status(HttpStatus.NOT_FOUND.value())
-        .message("데이터를 찾을 수 없습니다.")
-        .details(e.getMessage())
-        .build();
+    ErrorResponse response =
+        ErrorResponse.builder()
+            .status(HttpStatus.NOT_FOUND.value())
+            .message("잘못된 요청입니다.") // API 명세서에 맞게 수정했습니다.
+            .details(e.getMessage())
+            .build();
 
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }

--- a/src/test/java/com/codeit/findex/domain/indexinfo/service/IndexInfoServiceTest.java
+++ b/src/test/java/com/codeit/findex/domain/indexinfo/service/IndexInfoServiceTest.java
@@ -6,6 +6,7 @@ import com.codeit.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
 import com.codeit.findex.domain.indexinfo.repository.IndexInfoRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,13 +30,14 @@ class IndexInfoServiceTest {
     // given
     IndexInfoCreateRequest request =
         new IndexInfoCreateRequest(
-            "KOSPI시리즈", "IT 서비스", 200, LocalDate.of(2023, 1, 1), new BigDecimal("1000.00"), false);
+            "KOSPI시리즈", "IT 서비스", 200, LocalDate.of(2023, 1, 1), new BigDecimal("1000.00"), null);
 
     // when
     IndexInfoResponse indexInfo = indexInfoService.createIndexInfo(request);
 
     // then
     assertThat(indexInfo.id()).isNotNull();
+    assertThat(indexInfo.favorite()).isFalse(); // null로 들어왔으므로 false 여야함
     assertThat(indexInfo.indexClassification()).isEqualTo("KOSPI시리즈");
   }
 
@@ -60,14 +62,50 @@ class IndexInfoServiceTest {
   }
 
   @Test
+  @DisplayName("지수 정보를 id로 조회할 수 있다")
+  void findIndexInfoById() {
+    // given
+    IndexInfoCreateRequest request =
+        new IndexInfoCreateRequest(
+            "KOSPI시리즈", "IT 서비스", 200, LocalDate.of(2023, 1, 1), new BigDecimal("1000.00"), null);
+    IndexInfoResponse response = indexInfoService.createIndexInfo(request);
+
+    // when
+    IndexInfoResponse result = indexInfoService.readIndexInfoById(response.id());
+
+    // then
+    assertThat(result).isEqualTo(response);
+  }
+
+  /**
+   * TODO
+   * query validation / request validation 예외 공통 응답이 잘 나가는지 테스트 (성결님 코드 머지 후)
+   */
+
+  @Test
+  @DisplayName("존재하지 않는 id로 지수 정보를 요청할 수 없다.")
+  void notFindIndexInfoById() {
+    // given
+    Long id = 999L;
+
+    // when & then
+    assertThatThrownBy(() -> indexInfoService.readIndexInfoById(id))
+        .isInstanceOf(EntityNotFoundException.class)
+        .hasMessage("지수 정보를 찾을 수 없습니다 ID: " + id);
+  }
+
+  @Test
   @DisplayName("지수 정보를 수정할 수 있다.")
   void updateIndexInfo() {
     // given
-    IndexInfo dummy = IndexInfo.createByUser("KOSPI시리즈", "IT 서비스", 200, LocalDate.of(2023, 1, 1), new BigDecimal("1000.00"), false);
+    IndexInfo dummy =
+        IndexInfo.createByUser(
+            "KOSPI시리즈", "IT 서비스", 200, LocalDate.of(2023, 1, 1), new BigDecimal("1000.00"), false);
     IndexInfo savedInfo = indexInfoRepository.save(dummy);
 
     // when
-    IndexInfoUpdateRequest updateRequest = new IndexInfoUpdateRequest(300, LocalDate.of(2024, 1, 1), new BigDecimal("2000.00"), true);
+    IndexInfoUpdateRequest updateRequest =
+        new IndexInfoUpdateRequest(300, LocalDate.of(2024, 1, 1), new BigDecimal("2000.00"), true);
     indexInfoService.updateIndexInfo(savedInfo.getId(), updateRequest);
 
     em.flush(); // 서비스에서 변경된 내용을 DB로 보냄
@@ -78,7 +116,8 @@ class IndexInfoServiceTest {
 
     assertThat(savedInfo.getEmployedItemsCount()).isEqualTo(300);
     assertThat(savedInfo.getBasePointInTime()).isEqualTo(LocalDate.of(2024, 1, 1));
-    assertThat(savedInfo.getBaseIndex()).isEqualByComparingTo(new BigDecimal("2000.00")); // 소수점까지 비교 가능
+    assertThat(savedInfo.getBaseIndex())
+        .isEqualByComparingTo(new BigDecimal("2000.00")); // 소수점까지 비교 가능
     assertThat(savedInfo.getFavorite()).isTrue();
   }
 }


### PR DESCRIPTION
제목:


## 작업 내용
- IndexInfo Service 지수 정보 단건 조회 구현
- IndexInfo Controller 지수 정보 단건 조회 구현

## 변경 사항
- IndexInfoMapper에 IndexInfoResponse를 만든다는 의미로 toIndexInfoResponseCreateResponse => toIndexInfoRespone로 변경하였습니다.
- DTO의 통일성을 맞추고 도메인 엔티티에 로직을 추가해서 favorite이 null로 들어올 경우 false로 변경하도록 createByUser 메소드를 수정하였습니다.
- ExceptionHandler에서 EntityNotFoundException은 404를 보내고 API 명세서에 작성된 내용인 "잘못된 요청입니다"로 수정하였습니다.


## 테스트
- [x] 로컬 테스트 여부
  - 통합 테스트를 진행하였습니다.
   - 1. 유효한 아이디로 조회 (성공)
   - 2. 유효하지 않은 아이디로 조회 시 예외 (성공)
   - 3. [TODO] 성결님이 작성해주신 파라미터 바인딩 에러(id를 문자로 넣는 경우 등)에 대한 테스트는 추후 진행하겠습니다.
- [x] 컨벤션 부합 여부
 - Google Style Guide를 준수하였습니다.

Closes #21 