### PR TITLE
feat: 관심 지수 성과 조회 리팩토링 및 기간별 성과 계산 반영

### DIFF
--- a/src/main/java/com/codeit/findex/domain/common/enums/PerformancePeriodType.java
+++ b/src/main/java/com/codeit/findex/domain/common/enums/PerformancePeriodType.java
@@ -1,0 +1,7 @@
+package com.codeit.findex.domain.common.enums;
+
+public enum PerformancePeriodType {
+  DAILY,
+  WEEKLY,
+  MONTHLY
+}

--- a/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
@@ -1,24 +1,49 @@
 package com.codeit.findex.domain.indexdata.controller;
 
+import com.codeit.findex.domain.common.enums.PerformancePeriodType;
 import com.codeit.findex.domain.indexdata.dto.IndexDataFavoriteResponse;
 import com.codeit.findex.domain.indexdata.service.IndexDataService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/index-data")
 @RequiredArgsConstructor
+@Tag(name = "지수 데이터 API", description = "지수 데이터 관리 API")
 public class IndexDataController {
 
   private final IndexDataService indexDataService;
 
-  // 비어있을 경우도 200 + []
+  @Operation(
+      summary = "관심 지수 성과 조회",
+      description = "즐겨찾기로 등록된 지수들의 성과를 조회합니다.",
+      operationId = "getFavoriteIndexPerformances")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "관심 지수 성과 조회 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+      })
   @GetMapping("/performance/favorite")
-  public ResponseEntity<List<IndexDataFavoriteResponse>> getFavoritePerformances() {
-    return ResponseEntity.ok(indexDataService.getFavoritePerformances());
+  public ResponseEntity<List<IndexDataFavoriteResponse>> getFavoritePerformances(
+      @Parameter(
+              description = "성과 기간 유형 (DAILY, WEEKLY, MONTHLY)",
+              schema =
+                  @Schema(
+                      allowableValues = {"DAILY", "WEEKLY", "MONTHLY"},
+                      defaultValue = "DAILY"))
+          @RequestParam(name = "periodType", defaultValue = "DAILY")
+          PerformancePeriodType periodType) {
+    return ResponseEntity.ok(indexDataService.getFavoritePerformances(periodType));
   }
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataFavoriteResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataFavoriteResponse.java
@@ -1,18 +1,12 @@
 package com.codeit.findex.domain.indexdata.dto;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 
 public record IndexDataFavoriteResponse(
-    // indexInfo
-    Long indexId,
+    Long indexInfoId,
     String indexClassification,
     String indexName,
-
-    // indexData
-    LocalDate baseDate,
-    BigDecimal closingPrice,
     BigDecimal versus,
-    BigDecimal fluctuationRate
-) {
-}
+    BigDecimal fluctuationRate,
+    BigDecimal currentPrice,
+    BigDecimal beforePrice) {}

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataMapper.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataMapper.java
@@ -1,6 +1,7 @@
 package com.codeit.findex.domain.indexdata.dto;
 
 import com.codeit.findex.domain.indexdata.entity.IndexData;
+import java.math.BigDecimal;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -8,8 +9,13 @@ import org.mapstruct.ReportingPolicy;
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface IndexDataMapper {
 
-  @Mapping(source = "indexInfo.id", target = "indexId")
-  @Mapping(source = "indexInfo.indexClassification", target = "indexClassification")
-  @Mapping(source = "indexInfo.indexName", target = "indexName")
-  IndexDataFavoriteResponse toIndexDataFavoriteResponse(IndexData indexData);
+  @Mapping(source = "latest.indexInfo.id", target = "indexInfoId")
+  @Mapping(source = "latest.indexInfo.indexClassification", target = "indexClassification")
+  @Mapping(source = "latest.indexInfo.indexName", target = "indexName")
+  IndexDataFavoriteResponse toIndexDataFavoriteResponse(
+      IndexData latest,
+      BigDecimal versus,
+      BigDecimal fluctuationRate,
+      BigDecimal currentPrice,
+      BigDecimal beforePrice);
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -63,7 +63,7 @@ public class IndexDataService {
       BigDecimal versus = currentPrice.subtract(beforePrice);
 
       // 등락률 계산 - (현재가 - 이전가) / 이전가 * 100
-      BigDecimal fluctuationRate = BigDecimal.ZERO;
+      BigDecimal fluctuationRate = null;
       if (beforePrice.compareTo(BigDecimal.ZERO) != 0) {
         fluctuationRate =
             versus
@@ -71,7 +71,6 @@ public class IndexDataService {
                 .multiply(BigDecimal.valueOf(100))
                 .setScale(2, RoundingMode.HALF_UP);
       }
-
       responses.add(
           indexDataMapper.toIndexDataFavoriteResponse(
               latest, versus, fluctuationRate, currentPrice, beforePrice));
@@ -103,8 +102,10 @@ public class IndexDataService {
 
   @Transactional
   public IndexDataResponse update(Long id, IndexDataUpdateRequest request) {
-    IndexData indexData = indexDataRepository.findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("해당 지수 데이터가 없습니다. id=" + id));
+    IndexData indexData =
+        indexDataRepository
+            .findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("해당 지수 데이터가 없습니다. id=" + id));
 
     indexData.update(
         request.sourceType(),
@@ -116,8 +117,7 @@ public class IndexDataService {
         request.fluctuationRate(),
         request.tradingQuantity(),
         request.tradingPrice(),
-        request.marketTotalAmount()
-    );
+        request.marketTotalAmount());
     return IndexDataResponse.from(indexData);
   }
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -1,9 +1,14 @@
 package com.codeit.findex.domain.indexdata.service;
 
+import com.codeit.findex.domain.common.enums.PerformancePeriodType;
 import com.codeit.findex.domain.indexdata.dto.IndexDataFavoriteResponse;
 import com.codeit.findex.domain.indexdata.dto.IndexDataMapper;
 import com.codeit.findex.domain.indexdata.entity.IndexData;
 import com.codeit.findex.domain.indexdata.repository.IndexDataRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,18 +24,78 @@ public class IndexDataService {
   private final IndexDataRepository indexDataRepository;
   private final IndexDataMapper indexDataMapper;
 
-  public List<IndexDataFavoriteResponse> getFavoritePerformances() {
+  public List<IndexDataFavoriteResponse> getFavoritePerformances(
+      PerformancePeriodType performancePeriodType) {
     List<IndexData> favoriteIndexDataList =
         indexDataRepository.findByIndexInfo_FavoriteTrueOrderByIndexInfoIdAscBaseDateDesc();
 
-    // 지수별 최신 1건만 유지 - 최신 날짜
-    Map<Long, IndexData> latestByIndex = new LinkedHashMap<>();
+    Map<Long, List<IndexData>> groupedByIndex = new LinkedHashMap<>();
+
     for (IndexData favoriteIndexData : favoriteIndexDataList) {
-      latestByIndex.putIfAbsent(favoriteIndexData.getIndexInfo().getId(), favoriteIndexData);
+      Long indexInfoId = favoriteIndexData.getIndexInfo().getId();
+      groupedByIndex.computeIfAbsent(indexInfoId, key -> new ArrayList<>()).add(favoriteIndexData);
     }
 
-    return latestByIndex.values().stream()
-        .map(indexDataMapper::toIndexDataFavoriteResponse)
-        .toList();
+    List<IndexDataFavoriteResponse> responses = new ArrayList<>();
+
+    for (List<IndexData> indexDataList : groupedByIndex.values()) {
+      // 첫번째가 가장 날짜가 늦은(최신) 데이터
+      IndexData latest = indexDataList.get(0);
+
+      // 최신 데이터에 종가, 날짜가 없으면 건너뛰기
+      if (latest.getClosingPrice() == null || latest.getBaseDate() == null) {
+        continue;
+      }
+
+      LocalDate targetDate = getTargetDate(latest.getBaseDate(), performancePeriodType);
+      IndexData compareData = findCompareData(indexDataList, targetDate);
+
+      if (compareData == null
+          || compareData.getClosingPrice() == null
+          || compareData.getBaseDate() == null) {
+        continue;
+      }
+
+      BigDecimal currentPrice = latest.getClosingPrice();
+      BigDecimal beforePrice = compareData.getClosingPrice();
+      BigDecimal versus = currentPrice.subtract(beforePrice);
+
+      // 등락률 계산 - (현재가 - 이전가) / 이전가 * 100
+      BigDecimal fluctuationRate = BigDecimal.ZERO;
+      if (beforePrice.compareTo(BigDecimal.ZERO) != 0) {
+        fluctuationRate =
+            versus
+                .divide(beforePrice, 6, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+      }
+
+      responses.add(
+          indexDataMapper.toIndexDataFavoriteResponse(
+              latest, versus, fluctuationRate, currentPrice, beforePrice));
+    }
+    return responses;
+  }
+
+  // periodType에 따라 비교 기준 날짜 계산 메서드
+  private LocalDate getTargetDate(LocalDate latestDate, PerformancePeriodType periodType) {
+    return switch (periodType) {
+      case DAILY -> latestDate.minusDays(1);
+      case WEEKLY -> latestDate.minusWeeks(1);
+      case MONTHLY -> latestDate.minusMonths(1);
+    };
+  }
+
+  // periodType에 따라 비교할 데이터(compareData) 찾는 메서드
+  // targetDate보다 같거나 더 과거인 것 중 첫 번째(주말, 공휴일 대비)
+  private IndexData findCompareData(List<IndexData> indexDataList, LocalDate targetDate) {
+    for (int i = 1; i < indexDataList.size(); i++) {
+      IndexData indexData = indexDataList.get(i);
+
+      if (indexData.getBaseDate() != null && !indexData.getBaseDate().isAfter(targetDate)) {
+        return indexData;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## 작업 내용

indexdata 도메인 패키지 내에 관심 지수 성과 조회 API(`GET /api/index-data/performance/favorite`) 구현을 완료하였습니다.

## 변경 사항

- `periodType(DAILY, WEEKLY, MONTHLY)` 쿼리 파라미터를 반영해 기간 유형별 관심 지수 성과 조회가 가능하도록 수정했습니다.
- `IndexDataService`에서 기간별 비교 기준 날짜를 계산하고, 비교 대상 데이터를 찾아 `currentPrice`, `beforePrice`, `versus`, `fluctuationRate`를 직접 계산하도록 구현했습니다.
- `IndexDataController`에 Swagger 문서화 어노테이션(`@Tag`, `@Operation`, `@ApiResponses`, `@Parameter`)을 추가했습니다.
- `periodType` 요청 파라미터명을 Swagger 스펙과 동일하게 맞추었습니다.
- `develop` 브랜치 최신 변경사항(지수 데이터 수정 API 구현)을 feature 브랜치에 반영했습니다.

## 테스트

- [x] 로컬 테스트 여부
  - `./gradlew.bat test` 통과
- [x] 컨벤션 부합 여부
  - 구글 스타일 가이드를 준수하여 코드 포맷을 작성하였습니다.