### PR TITLE
feat: 지수 정보 요약 목록 조회

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
@@ -2,6 +2,7 @@ package com.codeit.findex.domain.indexinfo.controller;
 
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoResponse;
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoSummaryResponse;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.codeit.findex.domain.indexinfo.service.IndexInfoService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -53,6 +55,22 @@ public class IndexInfoController {
   public ResponseEntity<IndexInfoResponse> readIndexInfoById(@PathVariable Long id) {
     IndexInfoResponse response = indexInfoService.readIndexInfoById(id);
     return ResponseEntity.ok(response);
+  }
+
+  @Operation(
+      summary = "지수 정보 요약 목록 조회",
+      description = "지수 ID, 분류, 이름만 포함한 전체 지수 목록을 조회합니다.",
+      operationId = "getIndexInfoSummaries")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "지수 정보 요약 목록 조회 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+      })
+  @GetMapping("/summaries")
+  public ResponseEntity<List<IndexInfoSummaryResponse>> getIndexInfoSummaries() {
+    List<IndexInfoSummaryResponse> infoSummaryResponses =
+        indexInfoService.findAllIndexInfoSummaries();
+    return ResponseEntity.ok(infoSummaryResponses);
   }
 
   @Operation(

--- a/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoSummaryResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoSummaryResponse.java
@@ -1,0 +1,9 @@
+package com.codeit.findex.domain.indexinfo.dto;
+
+public record IndexInfoSummaryResponse(
+    Long id,
+    String indexClassification,
+    String indexName
+) {
+
+}

--- a/src/main/java/com/codeit/findex/domain/indexinfo/repository/IndexInfoRepository.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/repository/IndexInfoRepository.java
@@ -1,10 +1,18 @@
 package com.codeit.findex.domain.indexinfo.repository;
 
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoSummaryResponse;
 import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface IndexInfoRepository extends JpaRepository<IndexInfo, Long> {
 
   // API 요구사항: {지수 분류명}, {지수명} 조합값 중복 검증용
   boolean existsByIndexClassificationAndIndexName(String indexClassification, String indexName);
+
+  // 요약 목록 조회에만 사용되는 필드만 가져오도록 JPQL 사용
+  @Query(
+      "SELECT new com.codeit.findex.domain.indexinfo.dto.IndexInfoSummaryResponse(i.id, i.indexClassification, i.indexName) FROM IndexInfo i")
+  List<IndexInfoSummaryResponse> findAllSummaries();
 }

--- a/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
@@ -3,10 +3,12 @@ package com.codeit.findex.domain.indexinfo.service;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoResponse;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoMapper;
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoSummaryResponse;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
 import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
 import com.codeit.findex.domain.indexinfo.repository.IndexInfoRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,6 +52,10 @@ public class IndexInfoService {
             .findById(id)
             .orElseThrow(() -> new EntityNotFoundException("지수 정보를 찾을 수 없습니다 ID: " + id));
     return indexInfoMapper.toIndexInfoResponse(indexInfo);
+  }
+
+  public List<IndexInfoSummaryResponse> findAllIndexInfoSummaries() {
+    return indexInfoRepository.findAllSummaries();
   }
 
   @Transactional


### PR DESCRIPTION
## 작업 내용
지수 ID, 분류, 이름만 포함된 전체 지수 요약 목록을 조회하는 API(비즈니스 로직 및 엔드포인트)를 구현했습니다.


## 변경 사항
- **DTO 추가**: 요약 정보 반환용 `IndexInfoSummaryResponse`를 생성했습니다.
- **조회 최적화 (Projection)**: 반환에 필요한 필드가 3개뿐이므로, `IndexInfoRepository`에서 JPQL을 사용해 DB에서 해당 필드만 선별적으로 가져오도록 작성했습니다.
- **Mapper 생략**: 불필요한 객체 변환을 줄이기 위해 Service 계층에서 굳이 Mapper를 거치지 않고, Repository에서 DTO로 바로 조회하여 반환하도록 구현했습니다.


## 테스트
- [x] 로컬 테스트 여부
  -  포스트맨을 통해 정상적으로 요약 목록이 조회되는 것을 확인했습니다.

<img width="876" height="1052" alt="image" src="https://github.com/user-attachments/assets/b5b0605e-b3db-4246-98db-72cd211eacf7" />

- [x] 컨벤션 부합 여부
  - google-java-format을 사용했습니다.

## 기타
- 혹시 더 추가할 사항이 있다면 의견 부탁드립니다!

Closes #27