### PR TITLE
feat: 지수 데이터 수정 API (코드리뷰반영)

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataMapper.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataMapper.java
@@ -12,4 +12,7 @@ public interface IndexDataMapper {
   @Mapping(source = "indexInfo.indexClassification", target = "indexClassification")
   @Mapping(source = "indexInfo.indexName", target = "indexName")
   IndexDataFavoriteResponse toIndexDataFavoriteResponse(IndexData indexData);
+
+  @Mapping(source = "indexInfo.id", target = "indexInfoId")
+  com.codeit.findex.domain.indexdata.dto.response.IndexDataResponse toResponse(IndexData indexData);
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexDataUpdateRequest.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexDataUpdateRequest.java
@@ -1,20 +1,21 @@
 package com.codeit.findex.domain.indexdata.dto.request;
 
 import com.codeit.findex.domain.common.enums.SourceType;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record IndexDataUpdateRequest(
-    SourceType sourceType,
-    BigDecimal marketPrice,
-    BigDecimal closingPrice,
-    BigDecimal highPrice,
-    BigDecimal lowPrice,
-    BigDecimal versus,
-    BigDecimal fluctuationRate,
-    Long tradingQuantity,
-    Long tradingPrice,
-    Long marketTotalAmount
+    SourceType sourceType,       // 수집 출처
+    @PositiveOrZero(message = "시가는 0 이상이어야 합니다.") BigDecimal marketPrice,
+    @PositiveOrZero(message = "종가는 0 이상이어야 합니다.") BigDecimal closingPrice,
+    @PositiveOrZero(message = "고가는 0 이상이어야 합니다.") BigDecimal highPrice,
+    @PositiveOrZero(message = "저가는 0 이상이어야 합니다.") BigDecimal lowPrice,
+    BigDecimal versus,            // 전일 대비 증감액
+    BigDecimal fluctuationRate,   // 등락률 변동률
+    @PositiveOrZero(message = "거래량은는 0 이상이어야 합니다.") Long tradingQuantity,
+    @PositiveOrZero(message = "거래대금은 0 이상이어야 합니다.") Long tradingPrice,
+    @PositiveOrZero(message = "시가총액은 0 이상이어야 합니다.") Long marketTotalAmount
 ) {
 
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexDataResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexDataResponse.java
@@ -19,23 +19,4 @@ public record IndexDataResponse(
     Long tradingQuantity,
     Long tradingPrice,
     Long marketTotalAmount
-) {
-
-  public static IndexDataResponse from(IndexData indexData) {
-    return new IndexDataResponse(
-        indexData.getId(),
-        indexData.getIndexInfo().getId(),
-        indexData.getBaseDate(),
-        indexData.getSourceType(),
-        indexData.getMarketPrice(),
-        indexData.getClosingPrice(),
-        indexData.getHighPrice(),
-        indexData.getLowPrice(),
-        indexData.getVersus(),
-        indexData.getFluctuationRate(),
-        indexData.getTradingQuantity(),
-        indexData.getTradingPrice(),
-        indexData.getMarketTotalAmount()
-    );
-  }
-}
+) {}

--- a/src/main/java/com/codeit/findex/domain/indexdata/entity/IndexData.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/entity/IndexData.java
@@ -127,35 +127,15 @@ public class IndexData {
       Long tradingPrice,
       Long marketTotalAmount
   ) {
-    if (sourceType != null) {
       this.sourceType = sourceType;
-    }
-    if (marketPrice != null) {
       this.marketPrice = marketPrice;
-    }
-    if (closingPrice != null) {
       this.closingPrice = closingPrice;
-    }
-    if (highPrice != null) {
       this.highPrice = highPrice;
-    }
-    if (lowPrice != null) {
       this.lowPrice = lowPrice;
-    }
-    if (versus != null) {
       this.versus = versus;
-    }
-    if (fluctuationRate != null) {
       this.fluctuationRate = fluctuationRate;
-    }
-    if (tradingQuantity != null) {
       this.tradingQuantity = tradingQuantity;
-    }
-    if (tradingPrice != null) {
       this.tradingPrice = tradingPrice;
-    }
-    if (marketTotalAmount != null) {
       this.marketTotalAmount = marketTotalAmount;
-    }
   }
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -53,6 +53,6 @@ public class IndexDataService {
         request.tradingPrice(),
         request.marketTotalAmount()
     );
-    return IndexDataResponse.from(indexData);
+    return indexDataMapper.toResponse(indexData);
   }
 }


### PR DESCRIPTION
## 작업 내용
- 지수 데이터 수정 API 코드리뷰반영

## 변경 사항
- from 팩토리 메서드 제거, MapStruct 매핑 사용하였습니다.
- IndexData entity updata() 메소드 if (null) 체크방식 제거 하였습니다.
- DTO에 `@PositiveOrZero' 검증 하였습니다.
   - '@NotNull' 어노테이션을 걸어버리면 단 하나만 수정하고 싶을때도 모든 필드를 강제로 다 채워보내야 해서
   '@PositiveOrZero' 어노테이션을 사용하여 [값0이상 + null] 을 허용하여 사용자가 1개의 값만 입력하더라도 수정이 되게끔 하였습니다.(dto 단에서 null을 받았으면 DB에선 안변함)

## 테스트
- [x] 로컬 테스트 여부
- [x] 컨벤션 부합 여부

Closes #26 
