### PR TITLE
feat: 지수 정보 등록 API 구현

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
@@ -20,6 +20,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.codeit.findex.domain.indexdata.dto.request.IndexDataCreateRequest;
+import org.springframework.http.HttpStatus;
 
 @RestController
 @RequestMapping("/api/index-data")
@@ -82,4 +84,20 @@ public class IndexDataController {
   ) {
     return ResponseEntity.ok(indexDataService.getChart(id, request.periodType()));
   }
+
+
+
+  @Operation(
+          summary = "지수 데이터 등록",
+          description = "새로운 지수 데이터를 등록합니다."
+  )
+  @PostMapping
+  public ResponseEntity<IndexDataResponse> create(
+          @Valid @RequestBody IndexDataCreateRequest request
+  ) {
+    IndexDataResponse response = indexDataService.create(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataMapper.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataMapper.java
@@ -5,6 +5,8 @@ import java.math.BigDecimal;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
+import com.codeit.findex.domain.indexdata.dto.request.IndexDataCreateRequest;
+import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface IndexDataMapper {
@@ -26,4 +28,9 @@ public interface IndexDataMapper {
 
   @Mapping(source = "indexInfo.id", target = "indexInfoId")
   com.codeit.findex.domain.indexdata.dto.response.IndexDataResponse toResponse(IndexData indexData);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "indexInfo", source = "indexInfo")
+  @Mapping(target = "sourceType", source = "request.sourceType")
+  IndexData toEntity(IndexDataCreateRequest request, IndexInfo indexInfo);
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexDataCreateRequest.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexDataCreateRequest.java
@@ -1,0 +1,26 @@
+package com.codeit.findex.domain.indexdata.dto.request;
+
+
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record IndexDataCreateRequest(
+        @NotNull(message = "지수 정보 ID는 필수입니다.")
+        Long indexInfoId,
+
+        @NotNull(message = "기준일자는 필수입니다.")
+        LocalDate baseDate,
+
+        String sourceType,
+        BigDecimal marketPrice,
+        BigDecimal closingPrice,
+        BigDecimal highPrice,
+        BigDecimal lowPrice,
+        BigDecimal versus,
+        BigDecimal fluctuationRate,
+        Long tradingQuantity,
+        BigDecimal tradingPrice,
+        BigDecimal marketTotalAmount
+) {
+}

--- a/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepository.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepository.java
@@ -31,4 +31,6 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
   @EntityGraph(attributePaths = "indexInfo")
   Optional<IndexData> findFirstByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(
       Long indexInfoId, LocalDate baseDate);
+  // IndexDataRepository.java 내부에 추가
+  boolean existsByIndexInfo_IdAndBaseDate(Long indexInfoId, java.time.LocalDate baseDate);
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -25,6 +25,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import com.codeit.findex.domain.indexdata.dto.request.IndexDataCreateRequest;
+import jakarta.persistence.EntityNotFoundException;
+
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -275,5 +279,24 @@ public class IndexDataService {
         request.marketTotalAmount()
     );
     return indexDataMapper.toResponse(indexData);
+
   }
+  @Transactional
+  public IndexDataResponse create(IndexDataCreateRequest request) {
+    IndexInfo indexInfo = indexInfoRepository.findById(request.indexInfoId())
+            .orElseThrow(() -> new EntityNotFoundException("해당 지수 정보를 찾을 수 없습니다. id=" + request.indexInfoId()));
+
+    if (indexDataRepository.existsByIndexInfo_IdAndBaseDate(request.indexInfoId(), request.baseDate())) {
+      throw new IllegalArgumentException("해당 날짜의 데이터가 이미 존재합니다.");
+    }
+
+    IndexData indexData = indexDataMapper.toEntity(request, indexInfo);
+    IndexData savedData = indexDataRepository.save(indexData);
+
+    return indexDataMapper.toResponse(savedData);
+  }
+
+
+
+
 }


### PR DESCRIPTION
#작업내용 
- IndexDataController : 지수 데이터 저장을 위한 엔드포인트 구현
- IndexDataService : 생성요청시 'indexInfoId' 존재 여부를 검증하는 로직 추가

#변경사항

- 패키지 단일화 : 제가 구현했던 기존 mapper 패키지에 있던 IndexDataMapper을 팀원 컴벤션에 맞춰 dto패키지로 통합하고 이전함.

- 매퍼 기능 단일화 : 제가 구현한toResponse 기능과 팀원의 조회용 toIndexDataFavoriteResponse기능을 하나의 mapper 로 통일하여 bean충돌 해결.



#테스트
- [x] 로컬테스트 여부
      H2데이터 베이스에 샘플데이터 한개를 넣고, Postman으로 데이터가 등록되는지 확인함.
<img width="1009" height="851" alt="image" src="https://github.com/user-attachments/assets/229b75b0-aed3-416b-9023-5e3ac4e95a4e" />


- [x] 컨벤션 여부
      google style로 작업.