### PR TITLE
feat: 연동 작업 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
@@ -27,7 +27,9 @@ public class AutoSyncConfigController {
 
   private final AutoSyncConfigService autoSyncConfigService;
 
-  @Operation(summary = "자동 연동 설정 목록 조회", description = "자동 연동 설정 목록을 조회합니다. 필터링, 정렬, 커서 기반 페이지네이션을 지원합니다.", operationId = "getAutoSyncConfigList")
+  @Operation(summary = "자동 연동 설정 목록 조회",
+      description = "자동 연동 설정 목록을 조회합니다. 필터링, 정렬, 커서 기반 페이지네이션을 지원합니다.",
+      operationId = "getAutoSyncConfigList")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "자동 연동 설정 목록 조회 성공"),
       @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필터 값 등)"),
@@ -40,7 +42,9 @@ public class AutoSyncConfigController {
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "자동 연동 설정 수정", description = "기존 자동 연동 설정을 수정합니다.", operationId = "updateAutoSyncConfig")
+  @Operation(summary = "자동 연동 설정 수정",
+      description = "기존 자동 연동 설정을 수정합니다.",
+      operationId = "updateAutoSyncConfig")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "자동 연동 설정 수정 성공"),
       @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 설정 값 등)"),

--- a/src/main/java/com/codeit/findex/domain/syncjob/controller/SyncJobController.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/controller/SyncJobController.java
@@ -1,0 +1,39 @@
+package com.codeit.findex.domain.syncjob.controller;
+
+import com.codeit.findex.domain.syncjob.dto.SyncJobListRequest;
+import com.codeit.findex.domain.syncjob.dto.SyncJobPageResponse;
+import com.codeit.findex.domain.syncjob.service.SyncJobService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "연동 작업 API", description = "연동 작업 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sync-jobs")
+public class SyncJobController {
+
+  private final SyncJobService syncJobService;
+
+  @Operation(summary = "연동 작업 목록 조회",
+      description = "연동 작업 목록을 조회합니다. 필터링, 정렬, 커서 기반 페이지네이션을 지원합니다.",
+      operationId = "getSyncJobList")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "자동 연동 설정 목록 조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필터 값 등)"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @GetMapping
+  public ResponseEntity<SyncJobPageResponse> getSyncjobs(
+      @Valid SyncJobListRequest request) {
+    SyncJobPageResponse response = syncJobService.getSyncJobs(request);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobListRequest.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobListRequest.java
@@ -1,0 +1,31 @@
+package com.codeit.findex.domain.syncjob.dto;
+
+import com.codeit.findex.domain.common.enums.JobType;
+import com.codeit.findex.domain.common.enums.SyncResult;
+import com.codeit.findex.domain.syncjob.validation.ValidSyncJobDateRange;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@ValidSyncJobDateRange
+public record SyncJobListRequest(
+    JobType jobType,
+    Long indexInfoId,
+    LocalDate baseDateFrom,
+    LocalDate baseDateTo,
+    String worker,
+    LocalDateTime jobTimeFrom,
+    LocalDateTime jobTimeTo,
+    SyncResult status,
+    Long idAfter,
+    String cursor,
+    @Pattern(regexp = "^(targetDate|jobTime)$")
+    String sortField,
+    @Pattern(regexp = "^(asc|desc)$")
+    String sortDirection,
+    @Positive
+    Integer size
+) {
+
+}

--- a/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobMapper.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobMapper.java
@@ -1,0 +1,18 @@
+package com.codeit.findex.domain.syncjob.dto;
+
+import com.codeit.findex.domain.syncjob.entity.SyncJob;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface SyncJobMapper {
+
+  @Mapping(target = "indexInfoId", source = "indexInfo.id")
+  SyncJobResponse toSyncJobResponse(SyncJob syncJob);
+
+  List<SyncJobResponse> toSyncJobResponseList(List<SyncJob> syncJobList);
+
+
+}

--- a/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobMapper.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobMapper.java
@@ -1,7 +1,6 @@
 package com.codeit.findex.domain.syncjob.dto;
 
 import com.codeit.findex.domain.syncjob.entity.SyncJob;
-import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -11,8 +10,4 @@ public interface SyncJobMapper {
 
   @Mapping(target = "indexInfoId", source = "indexInfo.id")
   SyncJobResponse toSyncJobResponse(SyncJob syncJob);
-
-  List<SyncJobResponse> toSyncJobResponseList(List<SyncJob> syncJobList);
-
-
 }

--- a/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobPageResponse.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobPageResponse.java
@@ -1,0 +1,14 @@
+package com.codeit.findex.domain.syncjob.dto;
+
+import java.util.List;
+
+public record SyncJobPageResponse(
+    List<SyncJobResponse> content,
+    String nextCursor,
+    Long nextIdAfter,
+    Integer size,
+    Long totalElements,
+    Boolean hasNext
+) {
+
+}

--- a/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobResponse.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobResponse.java
@@ -1,0 +1,18 @@
+package com.codeit.findex.domain.syncjob.dto;
+
+import com.codeit.findex.domain.common.enums.JobType;
+import com.codeit.findex.domain.common.enums.SyncResult;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record SyncJobResponse(
+    Long id,
+    JobType JobType,
+    Long indexInfold,
+    LocalDate targetDate,
+    String worker,
+    LocalDateTime jobTime,
+    SyncResult result
+) {
+
+}

--- a/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobResponse.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobResponse.java
@@ -7,8 +7,8 @@ import java.time.LocalDateTime;
 
 public record SyncJobResponse(
     Long id,
-    JobType JobType,
-    Long indexInfold,
+    JobType jobType,
+    Long indexInfoId,
     LocalDate targetDate,
     String worker,
     LocalDateTime jobTime,

--- a/src/main/java/com/codeit/findex/domain/syncjob/repository/SyncJobRepository.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/repository/SyncJobRepository.java
@@ -1,0 +1,11 @@
+package com.codeit.findex.domain.syncjob.repository;
+
+import com.codeit.findex.domain.syncjob.entity.SyncJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface SyncJobRepository
+    extends JpaRepository<SyncJob, Long>, JpaSpecificationExecutor<SyncJob> {
+
+
+}

--- a/src/main/java/com/codeit/findex/domain/syncjob/repository/SyncJobRepository.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/repository/SyncJobRepository.java
@@ -7,5 +7,4 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 public interface SyncJobRepository
     extends JpaRepository<SyncJob, Long>, JpaSpecificationExecutor<SyncJob> {
 
-
 }

--- a/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
@@ -7,8 +7,6 @@ import com.codeit.findex.domain.syncjob.dto.SyncJobResponse;
 import com.codeit.findex.domain.syncjob.entity.SyncJob;
 import com.codeit.findex.domain.syncjob.repository.SyncJobRepository;
 import com.codeit.findex.domain.syncjob.specification.SyncJobSpecification;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -26,20 +24,14 @@ public class SyncJobService {
     Sort sort = createSort(request);
     Specification<SyncJob> specification = SyncJobSpecification.withConditions(request);
 
-    // 동적쿼리, 필터 조건으로 조회 및 정렬
-    List<SyncJob> syncJobs = syncJobRepository.findAll(specification, sort);
-
-    // 커서 뒤에 있는 데이터만 남김
     Integer requestSize = request.size();
     int size = (requestSize == null || requestSize <= 0) ? 10 : requestSize;
 
-    List<SyncJob> filteredItems = syncJobs.stream()
-        .filter(syncJob -> isAfterCursor(syncJob, request))
-        .toList();
-    // 현재 페이지 생성
-    boolean hasNext = filteredItems.size() > size;
+    List<SyncJob> syncJobs = syncJobRepository.findAll(specification, sort);
 
-    List<SyncJob> pageItems = filteredItems.stream()
+    boolean hasNext = syncJobs.size() > size;
+
+    List<SyncJob> pageItems = syncJobs.stream()
         .limit(size)
         .toList();
 
@@ -61,10 +53,6 @@ public class SyncJobService {
       }
     }
 
-    System.out.println("size param = " + request.size());
-    System.out.println("filteredItems size = " + filteredItems.size());
-    System.out.println("pageItems size = " + pageItems.size());
-
     return new SyncJobPageResponse(
         content,
         nextCursor,
@@ -75,35 +63,10 @@ public class SyncJobService {
     );
   }
 
-  private boolean isAfterCursor(SyncJob syncJob, SyncJobListRequest request) {
-    String cursor = request.cursor();
-    Long idAfter = request.idAfter();
-    String sortDirection = request.sortDirection();
-
-    if (cursor == null || idAfter == null) {
-      return true;
-    }
-
-    int compare;
-
-    if ("targetDate".equals(request.sortField())) {
-      LocalDate cursorDate = LocalDate.parse(cursor);
-      compare = syncJob.getTargetDate().compareTo(cursorDate);
-    } else {
-      LocalDateTime cursorDateTime = LocalDateTime.parse(cursor);
-      compare = syncJob.getJobTime().compareTo(cursorDateTime);
-    }
-
-    if ("desc".equalsIgnoreCase(sortDirection)) {
-      return compare < 0 || (compare == 0 && syncJob.getId() > idAfter);
-    }
-
-    return compare > 0 || (compare == 0 && syncJob.getId() > idAfter);
-  }
-
   private Sort createSort(SyncJobListRequest request) {
     String sortField = request.sortField();
     String sortDirection = request.sortDirection();
+
     String sortBy = "jobTime";
     if ("targetDate".equals(sortField)) {
       sortBy = "targetDate";

--- a/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
@@ -7,6 +7,8 @@ import com.codeit.findex.domain.syncjob.dto.SyncJobResponse;
 import com.codeit.findex.domain.syncjob.entity.SyncJob;
 import com.codeit.findex.domain.syncjob.repository.SyncJobRepository;
 import com.codeit.findex.domain.syncjob.specification.SyncJobSpecification;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -17,32 +19,91 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SyncJobService {
 
-  private final SyncJobRepository syncjobRepository;
+  private final SyncJobRepository syncJobRepository;
   private final SyncJobMapper syncJobMapper;
 
   public SyncJobPageResponse getSyncJobs(SyncJobListRequest request) {
     Sort sort = createSort(request);
     Specification<SyncJob> specification = SyncJobSpecification.withConditions(request);
 
-    List<SyncJob> syncJobs = syncjobRepository.findAll(specification, sort);
-    List<SyncJobResponse> content = syncJobs.stream()
+    // 동적쿼리, 필터 조건으로 조회 및 정렬
+    List<SyncJob> syncJobs = syncJobRepository.findAll(specification, sort);
+
+    // 커서 뒤에 있는 데이터만 남김
+    Integer requestSize = request.size();
+    int size = (requestSize == null || requestSize <= 0) ? 10 : requestSize;
+
+    List<SyncJob> filteredItems = syncJobs.stream()
+        .filter(syncJob -> isAfterCursor(syncJob, request))
+        .toList();
+    // 현재 페이지 생성
+    boolean hasNext = filteredItems.size() > size;
+
+    List<SyncJob> pageItems = filteredItems.stream()
+        .limit(size)
+        .toList();
+
+    List<SyncJobResponse> content = pageItems.stream()
         .map(syncJobMapper::toSyncJobResponse)
         .toList();
 
+    String nextCursor = null;
+    Long nextIdAfter = null;
+
+    if (hasNext && !pageItems.isEmpty()) {
+      SyncJob lastItem = pageItems.get(pageItems.size() - 1);
+      nextIdAfter = lastItem.getId();
+
+      if ("targetDate".equals(request.sortField())) {
+        nextCursor = String.valueOf(lastItem.getTargetDate());
+      } else {
+        nextCursor = String.valueOf(lastItem.getJobTime());
+      }
+    }
+
+    System.out.println("size param = " + request.size());
+    System.out.println("filteredItems size = " + filteredItems.size());
+    System.out.println("pageItems size = " + pageItems.size());
+
     return new SyncJobPageResponse(
         content,
-        null,
-        null,
+        nextCursor,
+        nextIdAfter,
         content.size(),
-        (long) content.size(),
-        false
+        (long) syncJobs.size(),
+        hasNext
     );
+  }
+
+  private boolean isAfterCursor(SyncJob syncJob, SyncJobListRequest request) {
+    String cursor = request.cursor();
+    Long idAfter = request.idAfter();
+    String sortDirection = request.sortDirection();
+
+    if (cursor == null || idAfter == null) {
+      return true;
+    }
+
+    int compare;
+
+    if ("targetDate".equals(request.sortField())) {
+      LocalDate cursorDate = LocalDate.parse(cursor);
+      compare = syncJob.getTargetDate().compareTo(cursorDate);
+    } else {
+      LocalDateTime cursorDateTime = LocalDateTime.parse(cursor);
+      compare = syncJob.getJobTime().compareTo(cursorDateTime);
+    }
+
+    if ("desc".equalsIgnoreCase(sortDirection)) {
+      return compare < 0 || (compare == 0 && syncJob.getId() > idAfter);
+    }
+
+    return compare > 0 || (compare == 0 && syncJob.getId() > idAfter);
   }
 
   private Sort createSort(SyncJobListRequest request) {
     String sortField = request.sortField();
     String sortDirection = request.sortDirection();
-
     String sortBy = "jobTime";
     if ("targetDate".equals(sortField)) {
       sortBy = "targetDate";

--- a/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
@@ -1,0 +1,58 @@
+package com.codeit.findex.domain.syncjob.service;
+
+import com.codeit.findex.domain.syncjob.dto.SyncJobListRequest;
+import com.codeit.findex.domain.syncjob.dto.SyncJobMapper;
+import com.codeit.findex.domain.syncjob.dto.SyncJobPageResponse;
+import com.codeit.findex.domain.syncjob.dto.SyncJobResponse;
+import com.codeit.findex.domain.syncjob.entity.SyncJob;
+import com.codeit.findex.domain.syncjob.repository.SyncJobRepository;
+import com.codeit.findex.domain.syncjob.specification.SyncJobSpecification;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SyncJobService {
+
+  private final SyncJobRepository syncjobRepository;
+  private final SyncJobMapper syncJobMapper;
+
+  public SyncJobPageResponse getSyncJobs(SyncJobListRequest request) {
+    Sort sort = createSort(request);
+    Specification<SyncJob> specification = SyncJobSpecification.withConditions(request);
+
+    List<SyncJob> syncJobs = syncjobRepository.findAll(specification, sort);
+    List<SyncJobResponse> content = syncJobs.stream()
+        .map(syncJobMapper::toSyncJobResponse)
+        .toList();
+
+    return new SyncJobPageResponse(
+        content,
+        null,
+        null,
+        content.size(),
+        (long) content.size(),
+        false
+    );
+  }
+
+  private Sort createSort(SyncJobListRequest request) {
+    String sortField = request.sortField();
+    String sortDirection = request.sortDirection();
+
+    String sortBy = "jobTime";
+    if ("targetDate".equals(sortField)) {
+      sortBy = "targetDate";
+    }
+
+    Sort.Direction direction = Sort.Direction.DESC;
+    if ("asc".equalsIgnoreCase(sortDirection)) {
+      direction = Sort.Direction.ASC;
+    }
+
+    return Sort.by(direction, sortBy);
+  }
+}

--- a/src/main/java/com/codeit/findex/domain/syncjob/specification/SyncJobSpecification.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/specification/SyncJobSpecification.java
@@ -1,0 +1,75 @@
+package com.codeit.findex.domain.syncjob.specification;
+
+import com.codeit.findex.domain.common.enums.JobType;
+import com.codeit.findex.domain.common.enums.SyncResult;
+import com.codeit.findex.domain.syncjob.dto.SyncJobListRequest;
+import com.codeit.findex.domain.syncjob.entity.SyncJob;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.domain.Specification;
+
+public class SyncJobSpecification {
+
+  private SyncJobSpecification() {
+  }
+
+  //필드별 조건을 메서드들로 쪼개서 마지막에 조합
+  public static Specification<SyncJob> withConditions(SyncJobListRequest request) {
+    return Specification.where(hasJobType(request.jobType()))
+        .and(hasIndexInfoId(request.indexInfoId()))
+        .and(targetDateFrom(request.baseDateFrom()))
+        .and(targetDateTo(request.baseDateTo()))
+        .and(hasWorker(request.worker()))
+        .and(jobTimeFrom(request.jobTimeFrom()))
+        .and(jobTimeTo(request.jobTimeTo()))
+        .and(hasResult(request.status()));
+  }
+
+  public static Specification<SyncJob> hasJobType(JobType jobType) {
+    return (root, query, criteriaBuilder) ->
+        jobType == null ? null : criteriaBuilder.equal(root.get("jobType"), jobType);
+  }
+
+  public static Specification<SyncJob> hasIndexInfoId(Long indexInfoId) {
+    return (root, query, criteriaBuilder) ->
+        indexInfoId ==
+            null ? null : criteriaBuilder.equal(root.get("indexInfo").get("id"), indexInfoId);
+  }
+
+  public static Specification<SyncJob> targetDateFrom(LocalDate baseDateFrom) {
+    return (root, query, criteriaBuilder) ->
+        baseDateFrom ==
+            null ? null
+            : criteriaBuilder.greaterThanOrEqualTo(root.get("targetDate"), baseDateFrom);
+  }
+
+  public static Specification<SyncJob> targetDateTo(LocalDate baseDateTo) {
+    return (root, query, criteriaBuilder) ->
+        baseDateTo ==
+            null ? null : criteriaBuilder.lessThanOrEqualTo(root.get("targetDate"), baseDateTo);
+  }
+
+  // 문자열에 공백 뿐인 경우에도 조건 추가 X (null and blank)
+  public static Specification<SyncJob> hasWorker(String worker) {
+    return (root, query, criteriaBuilder) ->
+        worker ==
+            null || worker.isBlank() ? null : criteriaBuilder.equal(root.get("worker"), worker);
+  }
+
+  public static Specification<SyncJob> jobTimeFrom(LocalDateTime jobTimeFrom) {
+    return (root, query, criteriaBuilder) ->
+        jobTimeFrom ==
+            null ? null : criteriaBuilder.greaterThanOrEqualTo(root.get("jobTime"), jobTimeFrom);
+  }
+
+  public static Specification<SyncJob> jobTimeTo(LocalDateTime jobTimeTo) {
+    return (root, query, criteriaBuilder) ->
+        jobTimeTo ==
+            null ? null : criteriaBuilder.lessThanOrEqualTo(root.get("jobTime"), jobTimeTo);
+  }
+
+  public static Specification<SyncJob> hasResult(SyncResult result) {
+    return (root, query, criteriaBuilder) ->
+        result == null ? null : criteriaBuilder.equal(root.get("result"), result);
+  }
+}

--- a/src/main/java/com/codeit/findex/domain/syncjob/specification/SyncJobSpecification.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/specification/SyncJobSpecification.java
@@ -22,7 +22,8 @@ public class SyncJobSpecification {
         .and(hasWorker(request.worker()))
         .and(jobTimeFrom(request.jobTimeFrom()))
         .and(jobTimeTo(request.jobTimeTo()))
-        .and(hasResult(request.status()));
+        .and(hasResult(request.status()))
+        .and(afterCursor(request));
   }
 
   public static Specification<SyncJob> hasJobType(JobType jobType) {
@@ -71,5 +72,61 @@ public class SyncJobSpecification {
   public static Specification<SyncJob> hasResult(SyncResult result) {
     return (root, query, criteriaBuilder) ->
         result == null ? null : criteriaBuilder.equal(root.get("result"), result);
+  }
+
+  public static Specification<SyncJob> afterCursor(SyncJobListRequest request) {
+    String cursor = request.cursor();
+    Long idAfter = request.idAfter();
+
+    if (cursor == null || idAfter == null) {
+      return null;
+    }
+
+    String sortField = request.sortField();
+    boolean isDesc = "desc".equalsIgnoreCase(request.sortDirection());
+
+    return (root, query, cb) -> {
+      if ("targetDate".equals(sortField)) {
+        LocalDate cursorDate = LocalDate.parse(cursor);
+
+        if (isDesc) {
+          return cb.or(
+              cb.lessThan(root.get("targetDate"), cursorDate),
+              cb.and(
+                  cb.equal(root.get("targetDate"), cursorDate),
+                  cb.greaterThan(root.get("id"), idAfter)
+              )
+          );
+        }
+
+        return cb.or(
+            cb.greaterThan(root.get("targetDate"), cursorDate),
+            cb.and(
+                cb.equal(root.get("targetDate"), cursorDate),
+                cb.greaterThan(root.get("id"), idAfter)
+            )
+        );
+      }
+
+      LocalDateTime cursorDateTime = LocalDateTime.parse(cursor);
+
+      if (isDesc) {
+        return cb.or(
+            cb.lessThan(root.get("jobTime"), cursorDateTime),
+            cb.and(
+                cb.equal(root.get("jobTime"), cursorDateTime),
+                cb.greaterThan(root.get("id"), idAfter)
+            )
+        );
+      }
+
+      return cb.or(
+          cb.greaterThan(root.get("jobTime"), cursorDateTime),
+          cb.and(
+              cb.equal(root.get("jobTime"), cursorDateTime),
+              cb.greaterThan(root.get("id"), idAfter)
+          )
+      );
+    };
   }
 }

--- a/src/main/java/com/codeit/findex/domain/syncjob/validation/SyncJobDateRangeValidator.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/validation/SyncJobDateRangeValidator.java
@@ -1,0 +1,33 @@
+package com.codeit.findex.domain.syncjob.validation;
+
+import com.codeit.findex.domain.syncjob.dto.SyncJobListRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class SyncJobDateRangeValidator
+    implements ConstraintValidator<ValidSyncJobDateRange, SyncJobListRequest> {
+
+  @Override
+  public boolean isValid(
+      SyncJobListRequest request,
+      ConstraintValidatorContext context // false일 때 기본 메시지 출력(globalError)
+  ) {
+    if (request == null) {
+      return true;
+    }
+
+    if (request.baseDateFrom() != null
+        && request.baseDateTo() != null
+        && request.baseDateFrom().isAfter(request.baseDateTo())) {
+      return false;
+    }
+
+    if (request.jobTimeFrom() != null
+        && request.jobTimeTo() != null
+        && request.jobTimeFrom().isAfter(request.jobTimeTo())) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/main/java/com/codeit/findex/domain/syncjob/validation/ValidSyncJobDateRange.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/validation/ValidSyncJobDateRange.java
@@ -1,0 +1,20 @@
+package com.codeit.findex.domain.syncjob.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE) // 클래스 위에 어노테이션을 붙여 두 가지 검증을 진행
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = SyncJobDateRangeValidator.class)
+public @interface ValidSyncJobDateRange {
+
+  String message() default "날짜 범위가 올바르지 않습니다."; // 기본 메시지
+
+  Class<?>[] groups() default {}; // 표준 형식, 사용 X
+
+  Class<? extends Payload>[] payload() default {}; // 표준 형식,  사용X
+}

--- a/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
@@ -51,9 +51,12 @@ public class GlobalExceptionHandler {
       MethodArgumentNotValidException e) {
     String details =
         e.getBindingResult().getFieldErrors().stream()
-            .findFirst()
+            .findFirst() // field Errors 먼저 확인
             .map(error -> error.getField() + ": " + error.getDefaultMessage())
-            .orElse("요청값이 올바르지 않습니다.");
+            .orElseGet(() -> e.getBindingResult().getGlobalErrors().stream()
+                .findFirst() // 없다면, globalErrors 확인
+                .map(error -> error.getDefaultMessage())
+                .orElse("요청값이 올바르지 않습니다.")); // 둘 다 없다면, 기본 문구 사용
 
     ErrorResponse response =
         ErrorResponse.builder()


### PR DESCRIPTION
## 작업 내용
연동 작업 목록 조회 API를 구현했습니다.

## 변경 사항
- 연동 작업 조회 요청/응답 DTO 작성
- Specification 기반 동적 쿼리 필터링 구현
- 정렬 조건 명세 반영
- 커서 기반 페이지네이션 구현
- SyncJob 응답 매핑에 MapStruct 적용

## 테스트
- [x] 로컬 테스트 여부
- 로컬 H2 환경에서 조회 및 페이지네이션 동작 테스트
- [x] 컨벤션 부합 여부
---
## 🔍 코드리뷰 요청 사항

### 요청 1
- **파일/위치**: src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
- **요청 내용**:
  > 커서 기반 페이지네이션을 구현했는데, `size + 1` 크기만큼 (페이지네이션 작업에만 필요한 만큼) 메모리에 객체를 가져오는 방식에 대해 궁금합니다 (코드 처음부터 재작성, 기존 구조 리팩터링 등 방식에 구애받지 않고 고려했을 때)
- **고민한 점**:
  > QueryDSL을 도입해서 커서 조건까지 명시적으로 쿼리화하는 것은 (limit(size + 1)를 직접 걸어주기) 직관적으로 보이지만 구현이 어려울 것 같다고 생각했습니다. 두번째로 Pageable을 limit/sort 전달용으로 도입 했을 때 정말 메모리 측면에서 개선이 이루어지는지에 대해 고민해봤는데, Pageable을 도입해서 커서 페이지네이션을 했다라고 말하기는 어려울 것 같다고 생각했습니다.



Closes #25