### PR TITLE
feat: 지수 정보 목록 커서 페이징 조회 API 구현 및 전역 예외 처리 강화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ out/
 .env.*
 application-secret.yml
 application-local.yml
+
+# Querydsl Q-classes
+/build/

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // Querydsl 의존성 추가 (Spring Boot 3.x Version)
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/controller/IndexInfoController.java
@@ -1,8 +1,6 @@
 package com.codeit.findex.domain.indexinfo.controller;
 
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoResponse;
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
+import com.codeit.findex.domain.indexinfo.dto.*;
 import com.codeit.findex.domain.indexinfo.service.IndexInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -21,6 +19,24 @@ import org.springframework.web.bind.annotation.*;
 public class IndexInfoController {
 
   private final IndexInfoService indexInfoService;
+
+  @Operation(
+          summary = "지수 정보 목록 조회",
+          description = "지수 정보 목록을 조회합니다. 필터링, 정렬, 커서 기반 페이지네이션을 지원합니다.",
+          operationId = "getIndexInfos")
+  @ApiResponses(
+          value = {
+                  @ApiResponse(responseCode = "200", description = "지수 정보 목록 조회 성공"),
+                  @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필터 값 등)"),
+                  @ApiResponse(responseCode = "500", description = "서버 오류")
+          })
+  @GetMapping
+  public ResponseEntity<IndexInfoCursorResponse<IndexInfoResponse>> getIndexInfos(
+          @Valid @ModelAttribute IndexInfoSearchCondition condition
+  ) {
+    IndexInfoCursorResponse<IndexInfoResponse> response = indexInfoService.getIndexInfos(condition);
+    return ResponseEntity.ok(response);
+  }
 
   @Operation(
       summary = "지수 정보 등록",

--- a/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoCursorResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoCursorResponse.java
@@ -1,0 +1,12 @@
+package com.codeit.findex.domain.indexinfo.dto;
+
+import java.util.List;
+
+public record IndexInfoCursorResponse<T>(
+        List<T> content,
+        String nextCursor,
+        Long nextIdAfter,
+        Integer size,
+        Long totalElements,
+        boolean hasNext
+) {}

--- a/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoSearchCondition.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/dto/IndexInfoSearchCondition.java
@@ -1,0 +1,35 @@
+package com.codeit.findex.domain.indexinfo.dto;
+
+import com.codeit.findex.domain.common.enums.SourceType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+
+// 검색 조건 DTO
+public record IndexInfoSearchCondition(
+    String indexClassification,
+    String indexName,
+    Boolean favorite,
+    Long idAfter,
+    String cursor,
+    @Pattern(
+            regexp = "^(indexClassification|indexName|employedItemsCount)$",
+            message = "정렬 필드는 indexClassification, indexName, employedItemsCount 중 하나여야 합니다.")
+        String sortField,
+    @Pattern(regexp = "^(?i)(asc|desc)$", message = "정렬 방향은 asc 또는 desc만 가능합니다.")
+        String sortDirection,
+    @Min(value = 1, message = "페이지 크기는 최소 1이상이어야 합니다.")
+        @Max(value = 100, message = "페이지 크기는 최대 100을 초과할 수 없습니다.")
+        Integer size) {
+  public String getSortField() {
+    return (sortField == null || sortField.isBlank()) ? "indexClassification" : sortField;
+  }
+
+  public String getSortDirection() {
+    return (sortDirection == null || sortDirection.isBlank()) ? "asc" : sortDirection;
+  }
+
+  public Integer getSize() {
+    return (size == null || size <= 0) ? 10 : size;
+  }
+}

--- a/src/main/java/com/codeit/findex/domain/indexinfo/repository/IndexInfoRepository.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/repository/IndexInfoRepository.java
@@ -3,7 +3,7 @@ package com.codeit.findex.domain.indexinfo.repository;
 import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface IndexInfoRepository extends JpaRepository<IndexInfo, Long> {
+public interface IndexInfoRepository extends JpaRepository<IndexInfo, Long>, IndexInfoRepositoryCustom {
 
   // API 요구사항: {지수 분류명}, {지수명} 조합값 중복 검증용
   boolean existsByIndexClassificationAndIndexName(String indexClassification, String indexName);

--- a/src/main/java/com/codeit/findex/domain/indexinfo/repository/IndexInfoRepositoryCustom.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/repository/IndexInfoRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.codeit.findex.domain.indexinfo.repository;
+
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoSearchCondition;
+import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
+
+import java.util.List;
+
+public interface IndexInfoRepositoryCustom {
+    // 데이터 목록 가져오기
+    List<IndexInfo> findAllByCondition(IndexInfoSearchCondition condition);
+
+    // 전체 개수 세기
+    long countByCondition(IndexInfoSearchCondition condition);
+}

--- a/src/main/java/com/codeit/findex/domain/indexinfo/repository/IndexInfoRepositoryImpl.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/repository/IndexInfoRepositoryImpl.java
@@ -1,0 +1,99 @@
+package com.codeit.findex.domain.indexinfo.repository;
+
+import com.codeit.findex.domain.indexinfo.dto.IndexInfoSearchCondition;
+import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.codeit.findex.domain.indexinfo.entity.QIndexInfo.indexInfo;
+
+@RequiredArgsConstructor
+public class IndexInfoRepositoryImpl implements IndexInfoRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<IndexInfo> findAllByCondition(IndexInfoSearchCondition condition) {
+        return queryFactory
+                .selectFrom(indexInfo)
+                .where(
+                        eqIndexClassification(condition.indexClassification()),
+                        containsIndexName(condition.indexName()),
+                        eqFavorite(condition.favorite()),
+                        getCursorCondition(condition)
+                )
+                .orderBy(getSortOrder(condition), indexInfo.id.asc())
+                .limit(condition.getSize() + 1)
+                .fetch();
+    }
+
+    @Override
+    public long countByCondition(IndexInfoSearchCondition condition) {
+        Long totalCount = queryFactory
+                .select(indexInfo.count())
+                .from(indexInfo)
+                .where(
+                        eqIndexClassification(condition.indexClassification()),
+                        containsIndexName(condition.indexName()),
+                        eqFavorite(condition.favorite())
+                )
+                .fetchOne();
+
+        return totalCount != null ? totalCount : 0L;
+    }
+
+    //
+    private BooleanExpression eqIndexClassification(String classification) {
+        return StringUtils.hasText(classification) ? indexInfo.indexClassification.eq(classification) : null;
+    }
+
+    private BooleanExpression containsIndexName(String name) {
+        return StringUtils.hasText(name) ? indexInfo.indexName.containsIgnoreCase(name) : null;
+    }
+
+    private BooleanExpression eqFavorite(Boolean favorite) {
+        return favorite != null ? indexInfo.favorite.eq(favorite) : null;
+    }
+
+    private OrderSpecifier<?> getSortOrder(IndexInfoSearchCondition condition) {
+        Order direction = condition.getSortDirection().equals("desc") ? Order.DESC : Order.ASC;
+
+        return switch (condition.getSortField()) {
+            case "indexName" -> new OrderSpecifier<>(direction, indexInfo.indexName);
+            case "employedItemsCount" -> new OrderSpecifier<>(direction, indexInfo.employedItemsCount);
+            default -> new OrderSpecifier<>(direction, indexInfo.indexClassification);
+        };
+    }
+
+    private BooleanExpression getCursorCondition(IndexInfoSearchCondition condition) {
+        if (!StringUtils.hasText(condition.cursor()) || condition.idAfter() == null) {
+            return null; // 첫 페이지 요청이면 커서 조건 무시
+        }
+
+        String sortField = condition.getSortField();
+        boolean isAsc = condition.getSortDirection().equals("asc");
+
+        return switch (sortField) {
+            case "indexName" -> isAsc
+                    ? indexInfo.indexName.gt(condition.cursor()).or(indexInfo.indexName.eq(condition.cursor()).and(indexInfo.id.gt(condition.idAfter())))
+                    : indexInfo.indexName.lt(condition.cursor()).or(indexInfo.indexName.eq(condition.cursor()).and(indexInfo.id.gt(condition.idAfter())));
+
+            case "employedItemsCount" -> {
+                int countCursor = Integer.parseInt(condition.cursor());
+                yield isAsc
+                        ? indexInfo.employedItemsCount.gt(countCursor).or(indexInfo.employedItemsCount.eq(countCursor).and(indexInfo.id.gt(condition.idAfter())))
+                        : indexInfo.employedItemsCount.lt(countCursor).or(indexInfo.employedItemsCount.eq(countCursor).and(indexInfo.id.gt(condition.idAfter())));
+            }
+
+            default -> isAsc // indexClassification
+                    ? indexInfo.indexClassification.gt(condition.cursor()).or(indexInfo.indexClassification.eq(condition.cursor()).and(indexInfo.id.gt(condition.idAfter())))
+                    : indexInfo.indexClassification.lt(condition.cursor()).or(indexInfo.indexClassification.eq(condition.cursor()).and(indexInfo.id.gt(condition.idAfter())));
+        };
+    }
+}

--- a/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
@@ -1,15 +1,14 @@
 package com.codeit.findex.domain.indexinfo.service;
 
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoCreateRequest;
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoResponse;
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoMapper;
-import com.codeit.findex.domain.indexinfo.dto.IndexInfoUpdateRequest;
+import com.codeit.findex.domain.indexinfo.dto.*;
 import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
 import com.codeit.findex.domain.indexinfo.repository.IndexInfoRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +17,50 @@ public class IndexInfoService {
 
   private final IndexInfoRepository indexInfoRepository;
   private final IndexInfoMapper indexInfoMapper;
+
+  public IndexInfoCursorResponse<IndexInfoResponse> getIndexInfos(IndexInfoSearchCondition condition) {
+
+    // 1. 데이터 목록 조회 (limit + 1)
+    List<IndexInfo> entities = indexInfoRepository.findAllByCondition(condition);
+
+    // 2. 전체 개수 카운트
+    long totalElements = indexInfoRepository.countByCondition(condition);
+
+    // 3. 다음 페이지 여부 계산
+    boolean hasNext = entities.size() > condition.getSize();
+    if (hasNext) {
+      entities.remove(condition.getSize().intValue());
+    }
+
+    // 4. 다음 페이지 요청용 커서 값 추출
+    String nextCursor = null;
+    Long nextIdAfter = null;
+    if (!entities.isEmpty()) {
+      IndexInfo lastItem = entities.get(entities.size() - 1);
+      nextIdAfter = lastItem.getId();
+
+      nextCursor = switch (condition.getSortField()) {
+        case "indexName" -> lastItem.getIndexName();
+        case "employedItemsCount" -> String.valueOf(lastItem.getEmployedItemsCount());
+        default -> lastItem.getIndexClassification();
+      };
+    }
+
+    // 5. Entity -> Dto 변환
+    List<IndexInfoResponse> dtoList = entities.stream()
+            .map(indexInfoMapper::toIndexInfoResponse)
+            .toList();
+
+    // 6. 응답 객체 조립 후 반환
+    return new IndexInfoCursorResponse<>(
+            dtoList,
+            nextCursor,
+            nextIdAfter,
+            condition.getSize(),
+            totalElements,
+            hasNext
+    );
+  }
 
   @Transactional
   public IndexInfoResponse createIndexInfo(IndexInfoCreateRequest request) {

--- a/src/main/java/com/codeit/findex/global/config/QuerydslConfig.java
+++ b/src/main/java/com/codeit/findex/global/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.codeit.findex.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    // https://batory.tistory.com/497
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
@@ -1,12 +1,15 @@
 package com.codeit.findex.global.error;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -34,18 +37,6 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
-  @ExceptionHandler(Exception.class)
-  public ResponseEntity<ErrorResponse> handlerGeneralException(Exception e) {
-    ErrorResponse response =
-        ErrorResponse.builder()
-            .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
-            .message("서버 내부 오류가 발생했습니다.")
-            .details(e.getMessage())
-            .build();
-
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
-  }
-
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> handlerMethodArgumentNotValidException(
       MethodArgumentNotValidException e) {
@@ -63,5 +54,39 @@ public class GlobalExceptionHandler {
             .build();
 
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  // @ModelAttribute 전용
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ErrorResponse> handlerBindException(BindException e) {
+    String details =
+        e.getBindingResult().getFieldErrors().stream()
+            .findFirst()
+            .map(error -> error.getField() + ": " + error.getDefaultMessage())
+            .orElse("요청 파라미터가 올바르지 않습니다.");
+
+    ErrorResponse response =
+        ErrorResponse.builder()
+            .status(HttpStatus.BAD_REQUEST.value())
+            .message("잘못된 요청입니다.")
+            .details(details)
+            .build();
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  // 500 에러
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handlerGeneralException(Exception e) {
+    log.error("Internal Server Error Occurred: ", e); // 클라이언트에게 서버 오류의 내역을 보여주지 않도록 처리
+
+    ErrorResponse response =
+        ErrorResponse.builder()
+            .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+            .message("서버 내부 오류가 발생했습니다.")
+            .details("관리자에게 문의해주세요.")
+            .build();
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
   }
 }


### PR DESCRIPTION
### 1. 작업 개요
- 지수 정보 목록 화면에서 사용할 필터링, 동적 정렬, 커서 기반 페이지네이션 API를 구현했습니다.
- 복잡한 동적 쿼리 처리를 위해 Querydsl 환경을 세팅하고 연동했습니다.
- 잘못된 파라미터 요청을 방어하고 안정적인 에러 응답을 제공하기 위해 GlobalExceptionHandler를 수정했습니다.

### 2. 주요 변경 사항
- **Querydsl 초기 세팅**
  - `build.gradle`에 Querydsl 의존성을 추가하고 `QuerydslConfig` 설정을 완료했습니다.
- **커서 기반 페이징 로직 구현 (`IndexInfoRepositoryImpl`)**
  - 스웨거 명세에 맞추어 동적 필터링(`indexClassification`, `indexName`, `favorite`)을 구현했습니다.
  - 동적 정렬을 적용하고, 동점자 누락 방지를 위해 보조 커서(`idAfter`)를 활용한 복합 커서 쿼리를 작성했습니다.
  - 페이징 응답에 필요한 전체 데이터 개수 조회를 위해 `countByCondition` 메서드를 추가했습니다.
- **API 레이어 구현 (`Controller`, `Service`, `DTO`)**
  - `GET /api/index-infos` 엔드포인트를 추가하고 Swagger 명세서를 작성했습니다.
  - `IndexInfoSearchCondition`(요청 DTO)에 `@Valid` 제약 조건을 추가하여 파라미터 검증 로직을 구현했습니다.
  - 기존 Mapper와 Response DTO를 재사용하여 아키텍처의 일관성을 유지했습니다.
- **전역 예외 처리 (`GlobalExceptionHandler`) 고도화**
  - GET 요청의 `@ModelAttribute` 바인딩 실패 시 발생하는 `BindException` 핸들러를 추가했습니다.
  - 500 Internal Server Error 발생 시 원본 예외 메시지(`e.getMessage()`)가 클라이언트에 노출되지 않도록 정제된 메시지를 반환하여 보안을 강화했습니다.

### 3. 테스트
<img width="702" height="759" alt="image" src="https://github.com/user-attachments/assets/14e81822-8040-43ae-ad90-b8bc3d71f33e" />
<img width="715" height="774" alt="image" src="https://github.com/user-attachments/assets/3eb17940-b177-4026-9ab5-3f4311394406" />
<img width="712" height="765" alt="image" src="https://github.com/user-attachments/assets/e64f36d1-31e9-468f-8b4e-7201d217d94c" />
<img width="713" height="854" alt="image" src="https://github.com/user-attachments/assets/3e25b4b7-ccdc-423e-b7d0-0d926ec55087" />
<img width="714" height="857" alt="image" src="https://github.com/user-attachments/assets/6b7aff52-5cd8-446f-88e8-2b6052d2aac0" />

Closes #33 