### PR TITLE
feat: 지수 차트 조회 API 구현

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
@@ -35,4 +35,17 @@ public class IndexDataController {
     IndexDataResponse response = indexDataService.update(id, request);
     return ResponseEntity.ok(response);
   }
+
+  @io.swagger.v3.oas.annotations.Operation(
+      summary = "지수 차트 조회",
+      description = "지수의 차트 데이터를 조회합니다."
+  )
+  @GetMapping("/{id}/chart")
+  public ResponseEntity<com.codeit.findex.domain.indexdata.dto.response.IndexChartResponse> getChart(
+      @io.swagger.v3.oas.annotations.Parameter(description = "지수 정보 ID")
+      @PathVariable Long id,
+      @jakarta.validation.Valid @org.springframework.web.bind.annotation.ModelAttribute com.codeit.findex.domain.indexdata.dto.request.IndexChartRequest request
+  ) {
+    return  ResponseEntity.ok(indexDataService.getChart(id, request.periodType()));
+  }
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexChartRequest.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexChartRequest.java
@@ -1,0 +1,12 @@
+package com.codeit.findex.domain.indexdata.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Schema(description = "지수 차트 조회 요청 DTO")
+public record IndexChartRequest(
+    @Schema(description = "조회 기간 유형", example = "MONTHLY")
+    @NotNull(message = "기간 유형은 필수입니다.")
+    PeriodType periodType
+) {}

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/request/PeriodType.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/request/PeriodType.java
@@ -1,0 +1,8 @@
+package com.codeit.findex.domain.indexdata.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "지수 차트 조회 기간 유형")
+public enum PeriodType {
+  MONTHLY, QUARTERLY, YEARLY
+}

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/response/ChartDataPoint.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/response/ChartDataPoint.java
@@ -1,0 +1,14 @@
+package com.codeit.findex.domain.indexdata.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Schema(description = "차트 단일 데이터 포인트 DTO")
+public record ChartDataPoint(
+    @Schema(description = "기준 일자", example = "2024-01-01")
+    LocalDate data,
+
+    @Schema(description = "수치 값(종가, 이동평균선 등)", example = "2850.50")
+    BigDecimal value
+) {}

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexChartResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexChartResponse.java
@@ -1,0 +1,28 @@
+package com.codeit.findex.domain.indexdata.dto.response;
+
+import com.codeit.findex.domain.indexdata.dto.request.PeriodType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record IndexChartResponse(
+    @Schema(description = "지수 정보 ID", example = "1")
+    Long indexInfoId,
+
+    @Schema(description = "지수 분류", example = "KOSPI")
+    String indexClassification,
+
+    @Schema(description = "지수명", example = "IT")
+    String indexName,
+
+    @Schema(description = "요청된 기간 유형", example = "MONTHLY")
+    PeriodType periodType,
+
+    @Schema(description = "차트 원본 데이터(종가) 목록")
+    List<ChartDataPoint> dataPints,
+
+    @Schema(description = "5일 이동평균선 데이터 목록")
+    List<ChartDataPoint> ma5DataPoints,
+
+    @Schema(description = "20일 이동평균선 데이터 목록")
+    List<ChartDataPoint> ma20DataPoints
+) {}

--- a/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepository.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepository.java
@@ -13,6 +13,6 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
   List<IndexData> findByIndexInfo_FavoriteTrueOrderByIndexInfoIdAscBaseDateDesc();
 
   @EntityGraph(attributePaths = "indexInfo")
-  List<IndexData> findByIndexInfoAndBaseDateBetweenOrderByBaseDateAsc(
+  List<IndexData> findByIndexInfoIdAndBaseDateBetweenOrderByBaseDateAsc(
       Long indexInfoId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepository.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepository.java
@@ -1,6 +1,7 @@
 package com.codeit.findex.domain.indexdata.repository;
 
 import com.codeit.findex.domain.indexdata.entity.IndexData;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,8 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
   // 추후 주석 삭제 및, QueryDSL 적용예정
   @EntityGraph(attributePaths = "indexInfo")
   List<IndexData> findByIndexInfo_FavoriteTrueOrderByIndexInfoIdAscBaseDateDesc();
+
+  @EntityGraph(attributePaths = "indexInfo")
+  List<IndexData> findByIndexInfoAndBaseDateBetweenOrderByBaseDateAsc(
+      Long indexInfoId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -3,9 +3,18 @@ package com.codeit.findex.domain.indexdata.service;
 import com.codeit.findex.domain.indexdata.dto.IndexDataFavoriteResponse;
 import com.codeit.findex.domain.indexdata.dto.IndexDataMapper;
 import com.codeit.findex.domain.indexdata.dto.request.IndexDataUpdateRequest;
+import com.codeit.findex.domain.indexdata.dto.request.PeriodType;
+import com.codeit.findex.domain.indexdata.dto.response.ChartDataPoint;
+import com.codeit.findex.domain.indexdata.dto.response.IndexChartResponse;
 import com.codeit.findex.domain.indexdata.dto.response.IndexDataResponse;
 import com.codeit.findex.domain.indexdata.entity.IndexData;
 import com.codeit.findex.domain.indexdata.repository.IndexDataRepository;
+import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
+import com.codeit.findex.domain.indexinfo.repository.IndexInfoRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,7 +28,74 @@ import org.springframework.transaction.annotation.Transactional;
 public class IndexDataService {
 
   private final IndexDataRepository indexDataRepository;
+  private final IndexInfoRepository indexInfoRepository;
   private final IndexDataMapper indexDataMapper;
+
+  public IndexChartResponse getChart(Long indexInfoId, PeriodType periodType) {
+    IndexInfo indexInfo = indexInfoRepository.findById(indexInfoId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 지수 정보가 없습니다. id=" + indexInfoId));
+
+    LocalDate endDate = LocalDate.now();
+    LocalDate startDate = switch (periodType) {
+      case MONTHLY -> endDate.minusMonths(1);
+      case QUARTERLY ->  endDate.minusMonths(3);
+      case YEARLY -> endDate.minusYears(1);
+    };
+
+    // 이동평균선 20일 계산을 위해 이전 40일치 데이터 여유분 확보
+    LocalDate fetchStartDate = startDate.minusDays(40);
+    List<IndexData> fetchedData = indexDataRepository
+        .findByIndexInfoIdAndBaseDateBetweenOrderByBaseDateAsc(indexInfoId, fetchStartDate, endDate);
+
+    List<ChartDataPoint> dataPoints = new ArrayList<>();
+    List<ChartDataPoint> ma5DataPoints = new ArrayList<>();
+    List<ChartDataPoint> ma20DataPoints = new ArrayList<>();
+
+    for (int i = 0; i < fetchedData.size(); i++) {
+      IndexData current = fetchedData.get(i);
+      LocalDate currentDate = current.getBaseDate();
+
+      // 5일 이동평균선 계산
+      BigDecimal ma5 = null;
+      if (i >= 4) {
+        BigDecimal sum5 = BigDecimal.ZERO;
+        for (int j = i -4; j < i; j++) {
+          sum5 = sum5.add(fetchedData.get(j).getClosingPrice());
+        }
+        ma5 = sum5.divide(BigDecimal.valueOf(5), 2, RoundingMode.HALF_UP);
+      }
+
+      // 20일 이동평균선 계산
+      BigDecimal ma20 = null;
+      if (i >= 19) {
+        BigDecimal sum20 = BigDecimal.ZERO;
+        for (int j = i - 19; j < i; j++) {
+          sum20 = sum20.add(fetchedData.get(j).getClosingPrice());
+        }
+        ma20 = sum20.divide(BigDecimal.valueOf(20), 2, RoundingMode.HALF_UP);
+      }
+
+      // 조회 결과는 요청된 시작일(startDate) 데이터부터만 차트 결과로 반환
+      if (!currentDate.isBefore(startDate)) {
+        dataPoints.add(new ChartDataPoint(currentDate, current.getClosingPrice()));
+        if (ma5 != null) {
+          ma5DataPoints.add(new ChartDataPoint(currentDate, ma5));
+          }
+        if (ma20 != null) {
+          ma20DataPoints.add(new ChartDataPoint(currentDate, ma20));
+        }
+      }
+    }
+    return  new IndexChartResponse(
+        indexInfo.getId(),
+        indexInfo.getIndexClassification(),
+        indexInfo.getIndexName(),
+        periodType,
+        dataPoints,
+        ma5DataPoints,
+        ma20DataPoints
+    );
+  }
 
   public List<IndexDataFavoriteResponse> getFavoritePerformances() {
     List<IndexData> favoriteIndexDataList =


### PR DESCRIPTION
## 작업 내용
Swagger 명세를 반영한 DTO 설계 및 컨트롤러를 구현했으며, 서비스 계층에서 40일간의 데이터 버퍼를 활용해 오차를 (주말,공휴일)에 의한 오차를 방지하였으며, 일반적으로 쓰이고 있는 이동평균선 공식 로직을 작성하였습니다.

## 변경 사항
- `GET /api/index-data/{id}/chart` 지수 차트 조회 API를 추가했습니다.
- `periodType`에 따라 월간, 분기, 연간 차트 조회 기간을 계산하도록 구현했습니다.
- 특정 지수의 종가 데이터를 조회하고, MA5/MA20 이동평균선을 계산해 응답하도록 구현했습니다.
- 이동평균선 계산을 위해 요청 시작일보다 40일 이전 데이터까지 조회한 뒤, 응답에는 요청 기간의 데이터만 포함되도록 처리했습니다.
- 금융 데이터 정밀도 유지를 위해 이동평균선 계산에 `BigDecimal`을 사용했습니다.
- 차트 조회 요청/응답을 위한 `IndexChartRequest`, `PeriodType`, `IndexChartResponse`, `ChartDataPoint` DTO를 추가했습니다.
- Repository에 지수 ID와 날짜 범위를 기준으로 데이터를 오름차순 조회하는 메서드를 추가했습니다.


## 스크린샷
<img width="946" height="846" alt="스크린샷 2026-04-20 오전 3 01 52" src="https://github.com/user-attachments/assets/50bba097-46b8-4faf-86cf-c6355159f420" />


