### PR TITLE
feat: 지수 성과 랭킹 API 구현

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
@@ -1,13 +1,21 @@
 package com.codeit.findex.domain.indexdata.controller;
 
 import com.codeit.findex.domain.indexdata.dto.IndexDataFavoriteResponse;
+import com.codeit.findex.domain.indexdata.dto.request.IndexChartRequest;
 import com.codeit.findex.domain.indexdata.dto.request.IndexDataUpdateRequest;
+import com.codeit.findex.domain.indexdata.dto.request.IndexPerformanceRankRequest;
+import com.codeit.findex.domain.indexdata.dto.response.IndexChartResponse;
 import com.codeit.findex.domain.indexdata.dto.response.IndexDataResponse;
+import com.codeit.findex.domain.indexdata.dto.response.RankedIndexPerformanceResponse;
 import com.codeit.findex.domain.indexdata.service.IndexDataService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +28,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class IndexDataController {
 
   private final IndexDataService indexDataService;
+
+  @Operation(
+      summary = "지수 성과 랭킹 조회",
+      description = "전일, 전주, 전월 대비 지수 성과를 등락률 기준 랭킹으로 조회합니다."
+  )
+  @GetMapping("/performance/rank")
+  public ResponseEntity<List<RankedIndexPerformanceResponse>> getPerformanceRank(
+      @Valid @ModelAttribute IndexPerformanceRankRequest request
+  ) {
+    return ResponseEntity.ok(indexDataService.getPerformanceRank(request));
+  }
 
   // 비어있을 경우도 200 + []
   @GetMapping("/performance/favorite")
@@ -36,16 +55,16 @@ public class IndexDataController {
     return ResponseEntity.ok(response);
   }
 
-  @io.swagger.v3.oas.annotations.Operation(
+  @Operation(
       summary = "지수 차트 조회",
       description = "지수의 차트 데이터를 조회합니다."
   )
   @GetMapping("/{id}/chart")
-  public ResponseEntity<com.codeit.findex.domain.indexdata.dto.response.IndexChartResponse> getChart(
-      @io.swagger.v3.oas.annotations.Parameter(description = "지수 정보 ID")
+  public ResponseEntity<IndexChartResponse> getChart(
+      @Parameter(description = "지수 정보 ID")
       @PathVariable Long id,
-      @jakarta.validation.Valid @org.springframework.web.bind.annotation.ModelAttribute com.codeit.findex.domain.indexdata.dto.request.IndexChartRequest request
+      @Valid @ModelAttribute IndexChartRequest request
   ) {
-    return  ResponseEntity.ok(indexDataService.getChart(id, request.periodType()));
+    return ResponseEntity.ok(indexDataService.getChart(id, request.periodType()));
   }
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexPerformanceRankRequest.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexPerformanceRankRequest.java
@@ -1,0 +1,22 @@
+package com.codeit.findex.domain.indexdata.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record IndexPerformanceRankRequest(
+    @Schema(description = "지수 정보 ID", example = "1")
+    @Positive(message = "지수 정보 ID는 양수여야 합니다.")
+    Long indexInfoId,
+
+    @Schema(description = "성과 비교 기간 유형", example = "DAILY")
+    @NotNull(message = "기간 유형은 필수입니다.")
+    UnitPeriodType periodType,
+
+    @Schema(description = "반환할 랭킹 개수", example = "10")
+    @Min(value = 1, message = "랭킹 개수는 1 이상이어야 합니다.")
+    Integer limit
+) {
+
+}

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/request/UnitPeriodType.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/request/UnitPeriodType.java
@@ -1,0 +1,10 @@
+package com.codeit.findex.domain.indexdata.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "지수 성과 랭킹 조회 기간 유형")
+public enum UnitPeriodType {
+  DAILY,
+  WEEKLY,
+  MONTHLY,
+}

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/response/ChartDataPoint.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/response/ChartDataPoint.java
@@ -4,11 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-@Schema(description = "차트 단일 데이터 포인트 DTO")
+@Schema(description = "차트 데이터 포인트")
 public record ChartDataPoint(
-    @Schema(description = "기준 일자", example = "2024-01-01")
-    LocalDate data,
+    @Schema(description = "날짜", example = "2023-01-01")
+    LocalDate date,
 
-    @Schema(description = "수치 값(종가, 이동평균선 등)", example = "2850.50")
+    @Schema(description = "값", example = "2850.75")
     BigDecimal value
 ) {}

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexChartResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexChartResponse.java
@@ -18,7 +18,7 @@ public record IndexChartResponse(
     PeriodType periodType,
 
     @Schema(description = "차트 원본 데이터(종가) 목록")
-    List<ChartDataPoint> dataPints,
+    List<ChartDataPoint> dataPoints,
 
     @Schema(description = "5일 이동평균선 데이터 목록")
     List<ChartDataPoint> ma5DataPoints,

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexPerformanceResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexPerformanceResponse.java
@@ -1,0 +1,30 @@
+package com.codeit.findex.domain.indexdata.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+public record IndexPerformanceResponse(
+    @Schema(description = "지수 정보 ID", example = "1")
+    Long indexInfoId,
+
+    @Schema(description = "지수 분류", example = "KOSPI")
+    String indexClassification,
+
+    @Schema(description = "지수명", example = "KOSPI 200")
+    String indexName,
+
+    @Schema(description = "기준가 대비 차이", example = "25.12")
+    BigDecimal versus,
+
+    @Schema(description = "기준가 대비 등락률", example = "1.42")
+    BigDecimal fluctuationRate,
+
+    @Schema(description = "현재 종가", example = "2800.35")
+    BigDecimal currentPrice,
+
+    @Schema(description = "비교 기준 종가", example = "2761.12")
+    BigDecimal beforePrice
+
+) {
+
+}

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/response/RankedIndexPerformanceResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/response/RankedIndexPerformanceResponse.java
@@ -1,0 +1,14 @@
+package com.codeit.findex.domain.indexdata.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "순위가 포함된 지수 성과 정보 DTO")
+public record RankedIndexPerformanceResponse(
+    @Schema(description = "지수 성과 정보")
+    IndexPerformanceResponse performance,
+
+    @Schema(description = "성과 순위", example = "1")
+    int rank
+) {
+
+}

--- a/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepository.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepository.java
@@ -3,6 +3,7 @@ package com.codeit.findex.domain.indexdata.repository;
 import com.codeit.findex.domain.indexdata.entity.IndexData;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,4 +16,16 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
   @EntityGraph(attributePaths = "indexInfo")
   List<IndexData> findByIndexInfoIdAndBaseDateBetweenOrderByBaseDateAsc(
       Long indexInfoId, LocalDate startDate, LocalDate endDate);
+
+  Optional<IndexData> findTopByOrderByBaseDateDesc();
+
+  @EntityGraph(attributePaths = "indexInfo")
+  List<IndexData> findByBaseDate(LocalDate baseDate);
+
+  @EntityGraph(attributePaths = "indexInfo")
+  List<IndexData> findByBaseDateAndIndexInfoId(LocalDate baseDate, Long indexInfoId);
+
+  @EntityGraph(attributePaths = "indexInfo")
+  Optional<IndexData> findFirstByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(
+      Long indexInfoId, LocalDate baseDate);
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -3,10 +3,14 @@ package com.codeit.findex.domain.indexdata.service;
 import com.codeit.findex.domain.indexdata.dto.IndexDataFavoriteResponse;
 import com.codeit.findex.domain.indexdata.dto.IndexDataMapper;
 import com.codeit.findex.domain.indexdata.dto.request.IndexDataUpdateRequest;
+import com.codeit.findex.domain.indexdata.dto.request.IndexPerformanceRankRequest;
 import com.codeit.findex.domain.indexdata.dto.request.PeriodType;
+import com.codeit.findex.domain.indexdata.dto.request.UnitPeriodType;
 import com.codeit.findex.domain.indexdata.dto.response.ChartDataPoint;
 import com.codeit.findex.domain.indexdata.dto.response.IndexChartResponse;
 import com.codeit.findex.domain.indexdata.dto.response.IndexDataResponse;
+import com.codeit.findex.domain.indexdata.dto.response.IndexPerformanceResponse;
+import com.codeit.findex.domain.indexdata.dto.response.RankedIndexPerformanceResponse;
 import com.codeit.findex.domain.indexdata.entity.IndexData;
 import com.codeit.findex.domain.indexdata.repository.IndexDataRepository;
 import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
@@ -15,9 +19,11 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +32,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class IndexDataService {
+
+  private static final int DEFAULT_RANK_LIMIT = 10;
 
   private final IndexDataRepository indexDataRepository;
   private final IndexInfoRepository indexInfoRepository;
@@ -59,7 +67,7 @@ public class IndexDataService {
       BigDecimal ma5 = null;
       if (i >= 4) {
         BigDecimal sum5 = BigDecimal.ZERO;
-        for (int j = i -4; j < i; j++) {
+        for (int j = i - 4; j <= i; j++) {
           sum5 = sum5.add(fetchedData.get(j).getClosingPrice());
         }
         ma5 = sum5.divide(BigDecimal.valueOf(5), 2, RoundingMode.HALF_UP);
@@ -69,7 +77,7 @@ public class IndexDataService {
       BigDecimal ma20 = null;
       if (i >= 19) {
         BigDecimal sum20 = BigDecimal.ZERO;
-        for (int j = i - 19; j < i; j++) {
+        for (int j = i - 19; j <= i; j++) {
           sum20 = sum20.add(fetchedData.get(j).getClosingPrice());
         }
         ma20 = sum20.divide(BigDecimal.valueOf(20), 2, RoundingMode.HALF_UP);
@@ -111,6 +119,97 @@ public class IndexDataService {
         .map(indexDataMapper::toIndexDataFavoriteResponse)
         .toList();
   }
+
+  public List<RankedIndexPerformanceResponse> getPerformanceRank(
+      IndexPerformanceRankRequest request) {
+    LocalDate currentDate = indexDataRepository.findTopByOrderByBaseDateDesc()
+        .orElseThrow(() -> new IllegalStateException("지수 데이터가 없습니다."))
+        .getBaseDate();
+    LocalDate targetDate = getRankTargetDate(currentDate, request.periodType());
+    List<IndexData> currentDataList = findCurrentData(currentDate, request.indexInfoId());
+
+    List<IndexPerformanceResponse> performances = new ArrayList<>();
+    for (IndexData currentData : currentDataList) {
+      toIndexPerformance(currentData, targetDate).ifPresent(performances::add);
+    }
+
+    performances.sort(
+        Comparator.comparing(IndexPerformanceResponse::fluctuationRate).reversed());
+
+    int limit = resolveRankLimit(request.limit());
+    List<RankedIndexPerformanceResponse> ranks = new ArrayList<>();
+    for (int i = 0; i < performances.size() && i < limit; i++) {
+      ranks.add(new RankedIndexPerformanceResponse(performances.get(i), i + 1));
+    }
+    return ranks;
+  }
+
+  private LocalDate getRankTargetDate(LocalDate currentDate, UnitPeriodType periodType) {
+    if (periodType == null) {
+      throw new IllegalArgumentException("기간 유형은 필수입니다.");
+    }
+    return switch (periodType) {
+      case DAILY -> currentDate.minusDays(1);
+      case WEEKLY -> currentDate.minusWeeks(1);
+      case MONTHLY -> currentDate.minusMonths(1);
+    };
+  }
+
+  private List<IndexData> findCurrentData(LocalDate currentDate, Long indexInfoId) {
+    if (indexInfoId == null) {
+      return indexDataRepository.findByBaseDate(currentDate);
+    }
+    return indexDataRepository.findByBaseDateAndIndexInfoId(currentDate, indexInfoId);
+  }
+
+  private Optional<IndexPerformanceResponse> toIndexPerformance(
+      IndexData currentData, LocalDate targetDate) {
+    if (currentData.getClosingPrice() == null) {
+      return Optional.empty();
+    }
+
+    IndexInfo indexInfo = currentData.getIndexInfo();
+    Optional<IndexData> compareDataOptional =
+        indexDataRepository.findFirstByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(
+            indexInfo.getId(), targetDate);
+    if (compareDataOptional.isEmpty()) {
+      return Optional.empty();
+    }
+
+    IndexData compareData = compareDataOptional.get();
+    BigDecimal beforePrice = compareData.getClosingPrice();
+    if (beforePrice == null || beforePrice.compareTo(BigDecimal.ZERO) == 0) {
+      return Optional.empty();
+    }
+
+    BigDecimal currentPrice = currentData.getClosingPrice();
+    BigDecimal versus = currentPrice.subtract(beforePrice);
+    BigDecimal fluctuationRate = versus
+        .divide(beforePrice, 6, RoundingMode.HALF_UP)
+        .multiply(BigDecimal.valueOf(100))
+        .setScale(2, RoundingMode.HALF_UP);
+
+    return Optional.of(new IndexPerformanceResponse(
+        indexInfo.getId(),
+        indexInfo.getIndexClassification(),
+        indexInfo.getIndexName(),
+        versus,
+        fluctuationRate,
+        currentPrice,
+        beforePrice
+    ));
+  }
+
+  private int resolveRankLimit(Integer limit) {
+    if (limit == null) {
+      return DEFAULT_RANK_LIMIT;
+    }
+    if (limit < 1) {
+      throw new IllegalArgumentException("랭킹 개수는 1 이상이어야 합니다.");
+    }
+    return limit;
+  }
+
 
   @Transactional
   public IndexDataResponse update(Long id, IndexDataUpdateRequest request) {

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -40,7 +40,6 @@ public class IndexDataService {
   private final IndexInfoRepository indexInfoRepository;
   private final IndexDataMapper indexDataMapper;
 
-  // ✅ 팀원 코드: PerformancePeriodType 파라미터 받는 버전 사용
   public List<IndexDataFavoriteResponse> getFavoritePerformances(
       PerformancePeriodType performancePeriodType) {
     List<IndexData> favoriteIndexDataList =
@@ -107,7 +106,6 @@ public class IndexDataService {
     return null;
   }
 
-  // ✅ 내 코드: getPerformanceRank 유지
   public List<RankedIndexPerformanceResponse> getPerformanceRank(
       IndexPerformanceRankRequest request) {
     LocalDate currentDate = indexDataRepository.findTopByOrderByBaseDateDesc()

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -197,7 +197,6 @@ public class IndexDataService {
     return limit;
   }
 
-  // ✅ 내 코드: getChart - j <= i 버전이 정확함
   public IndexChartResponse getChart(Long indexInfoId, PeriodType periodType) {
     IndexInfo indexInfo = indexInfoRepository.findById(indexInfoId)
         .orElseThrow(() -> new IllegalArgumentException("해당 지수 정보가 없습니다. id=" + indexInfoId));


### PR DESCRIPTION
## 작업 내용

## 변경 사항
- 지수 성과 랭킹 조회 기간 타입 `UnitPeriodType`을 추가했습니다.
- 랭킹 조회 query parameter를 받기 위한 `IndexPerformanceRankRequest`를 추가했습니다.
- 지수 성과 정보를 표현하는 `IndexPerformanceResponse`를 추가했습니다.
- 순위가 포함된 최종 응답 DTO `RankedIndexPerformanceResponse`를 추가했습니다.
- DB에 저장된 최신 기준일을 찾기 위한 `findTopByOrderByBaseDateDesc()`를 추가했습니다.
- 특정 기준일의 전체 지수 데이터를 조회하는 `findByBaseDate()`를 추가했습니다.
- 특정 지수의 기준일 데이터를 조회하는 `findByBaseDateAndIndexInfoId()`를 추가했습니다.
- 비교 기준일 이전의 가장 가까운 데이터를 찾는 조회 메서드를 추가했습니다.
- `IndexDataService.getPerformanceRank()`를 추가했습니다.
- `periodType`에 따라 전일/전주/전월 비교 기준일을 계산하도록 구현했습니다.
- 현재가와 기준가를 비교해 `versus`, `fluctuationRate`를 계산하도록 구현했습니다.
- 등락률 내림차순 정렬 후 `limit`만큼 순위를 부여하도록 구현했습니다.
- `GET /api/index-data/performance/rank` 엔드포인트를 추가했습니다.
- `@ModelAttribute`로 query parameter를 요청 DTO에 바인딩하도록 구현했습니다.
- `@Valid`를 적용해 `periodType`, `limit`, `indexInfoId` 검증이 동작하도록 했습니다.
- Swagger 문서화를 위해 랭킹 조회 API에 `@Operation` 설명을 추가했습니다.

- API 명세서와 맞게 리펙터링 하였습니다.
- 오타 수정하였습니다.
- 5일,20일 이동평균선 계산 로직 일부 수정하였습니다.
- import 문제 해결하였습니다.