### PR TITLE
fix: 연동 작업 성공/실패 이력 트랜잭션 분리 처리

### DIFF
--- a/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
@@ -29,12 +29,16 @@ import java.util.LinkedHashSet;
 import com.codeit.findex.domain.syncjob.specification.SyncJobSpecification;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +57,7 @@ public class SyncJobService {
   private final IndexInfoRepository indexInfoRepository;
   private final IndexDataRepository indexDataRepository;
   private final SyncJobMapper syncJobMapper;
+  private final PlatformTransactionManager transactionManager;
 
   @Transactional
   public List<IndexInfoSyncJobResponse> syncIndexInfos(String worker) {
@@ -91,7 +96,10 @@ public class SyncJobService {
   }
 
   private SyncJob saveIndexInfosSyncJob(OpenApiIndexInfoResponse row, String worker) {
+    LocalDate targetDate = (row == null) ? null : row.basePointInTime();
+
     try {
+      return executeInNewTransaction(() -> {
       validateIndexInfosRow(row);
 
       IndexInfo indexInfo = upsertIndexInfos(row);
@@ -101,24 +109,26 @@ public class SyncJobService {
               null,
               JobType.INDEX_INFO,
               indexInfo,
-              row.basePointInTime(),
+              targetDate,
               worker,
               LocalDateTime.now(),
               SyncResult.SUCCESS);
       return syncJobRepository.save(successJob);
+      });
     } catch (RuntimeException e) {
+      return executeInNewTransaction(() -> {
       SyncJob failedJob =
           SyncJob.create(
               null,
               JobType.INDEX_INFO,
               null,
-              row.basePointInTime(),
+              targetDate,
               worker,
               LocalDateTime.now(),
               SyncResult.FAILED);
       return syncJobRepository.save(failedJob);
-    }
-  }
+    });
+  }}
 
   private void validateIndexInfosRow(OpenApiIndexInfoResponse row) {
     if (row.employedItemsCount() == null) {
@@ -228,34 +238,39 @@ public class SyncJobService {
     LocalDate targetDate = (row == null) ? null : row.baseDate();
 
     try {
-      validateIndexDataRow(row);
+      return executeInNewTransaction(
+          () -> {
+            validateIndexDataRow(row);
 
-      IndexInfo indexInfo = findOrCreateIndexInfo(row);
-      upsertIndexData(row, indexInfo);
+            IndexInfo indexInfo = findOrCreateIndexInfo(row);
+            upsertIndexData(row, indexInfo);
 
-      SyncJob successJob =
-          SyncJob.create(
-              null,
-              JobType.INDEX_DATA,
-              indexInfo,
-              targetDate,
-              worker,
-              LocalDateTime.now(),
-              SyncResult.SUCCESS);
+            SyncJob successJob =
+                SyncJob.create(
+                    null,
+                    JobType.INDEX_DATA,
+                    indexInfo,
+                    targetDate,
+                    worker,
+                    LocalDateTime.now(),
+                    SyncResult.SUCCESS);
 
-      return syncJobRepository.save(successJob);
+            return syncJobRepository.save(successJob);
+          });
     } catch (RuntimeException e) {
-      SyncJob failedJob =
-          SyncJob.create(
-              null,
-              JobType.INDEX_DATA,
-              null,
-              targetDate,
-              worker,
-              LocalDateTime.now(),
-              SyncResult.FAILED);
-
-      return syncJobRepository.save(failedJob);
+      return executeInNewTransaction(
+          () -> {
+            SyncJob failedJob =
+                SyncJob.create(
+                    null,
+                    JobType.INDEX_DATA,
+                    null,
+                    targetDate,
+                    worker,
+                    LocalDateTime.now(),
+                    SyncResult.FAILED);
+            return syncJobRepository.save(failedJob);
+          });
     }
   }
 
@@ -346,13 +361,10 @@ public class SyncJobService {
 
     boolean hasNext = syncJobs.size() > size;
 
-    List<SyncJob> pageItems = syncJobs.stream()
-        .limit(size)
-        .toList();
+    List<SyncJob> pageItems = syncJobs.stream().limit(size).toList();
 
-    List<SyncJobResponse> content = pageItems.stream()
-        .map(syncJobMapper::toSyncJobResponse)
-        .toList();
+    List<SyncJobResponse> content =
+        pageItems.stream().map(syncJobMapper::toSyncJobResponse).toList();
 
     String nextCursor = null;
     Long nextIdAfter = null;
@@ -369,13 +381,7 @@ public class SyncJobService {
     }
 
     return new SyncJobPageResponse(
-        content,
-        nextCursor,
-        nextIdAfter,
-        content.size(),
-        (long) syncJobs.size(),
-        hasNext
-    );
+        content, nextCursor, nextIdAfter, content.size(), (long) syncJobs.size(), hasNext);
   }
 
   private Sort createSort(SyncJobListRequest request) {
@@ -393,5 +399,11 @@ public class SyncJobService {
     }
 
     return Sort.by(direction, sortBy);
+  }
+
+  private <T> T executeInNewTransaction(Supplier<T> action) {
+    TransactionTemplate tx = new TransactionTemplate(transactionManager);
+    tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    return tx.execute(status -> action.get());
   }
 }


### PR DESCRIPTION
## 변경 내용
- SyncJobService에서 연동 처리 시 트랜잭션 경계를 분리했습니다.
- 성공 경로(`upsert + SUCCESS 이력`)와 실패 경로(`FAILED 이력`)를 각각 독립 트랜잭션(`REQUIRES_NEW`)으로 실행하도록 변경했습니다.
- `saveIndexDataSyncJob`, `saveIndexInfosSyncJob`에 동일 패턴 적용했습니다.

## 변경 이유
- 기존에는 예외 처리 구조상 데이터 반영과 실패 이력이 함께 기록될 수 있는 불일치 가능성이 있었습니다. (코드리뷰 내용)

## 추가사항
- `PlatformTransactionManager / REQUIRES_NEW` 개념이 아직 익숙하지 않아, 관련 피드백 주시면 감사하겠습니다.

## 동작 방식
```java
// PlatformTransactionManager를 주입받아 TransactionTemplate 기반으로 트랜잭션을 명시적으로 제어
private <T> T executeInNewTransaction(Supplier<T> action) {
    // 트랜잭션 템플릿 생성
    TransactionTemplate tx = new TransactionTemplate(transactionManager);

    // 항상 새 트랜잭션으로 실행하도록 전파 옵션 설정(기존 트랜잭션을 잠시 중단하고 새 트랜잭션을 시작)
    tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);

    // 실행 성공 시 커밋, 예외 발생 시 롤백 후 예외 전파
    return tx.execute(status -> action.get());
  }
```

