### PR TITLE
fix: 데이터 수정API 유효성 검사 수정 및 랭킹조회API 빈 리스트 반환

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
@@ -81,7 +81,7 @@ public class IndexDataController {
 
   @PatchMapping("/{id}")
   public ResponseEntity<IndexDataResponse> update(
-      @PathVariable Long id, @RequestBody IndexDataUpdateRequest request) {
+      @PathVariable Long id, @Valid @RequestBody IndexDataUpdateRequest request) {
     IndexDataResponse response = indexDataService.update(id, request);
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -161,11 +161,12 @@ public class IndexDataService {
 
   public List<RankedIndexPerformanceResponse> getPerformanceRank(
       IndexPerformanceRankRequest request) {
-    LocalDate currentDate =
-        indexDataRepository
-            .findTopByOrderByBaseDateDesc()
-            .orElseThrow(() -> new IllegalStateException("지수 데이터가 없습니다."))
-            .getBaseDate();
+    Optional<IndexData> latestData = indexDataRepository.findTopByOrderByBaseDateDesc();
+    if (latestData.isEmpty()) {
+      return new ArrayList<>();
+    }
+
+    LocalDate currentDate = latestData.get().getBaseDate();
     LocalDate targetDate = getRankTargetDate(currentDate, request.periodType());
     List<IndexData> currentDataList = findCurrentData(currentDate, request.indexInfoId());
 


### PR DESCRIPTION
## 작업 내용
- 데이터 수정 API 유효성 검증 활성화
- 랭킹 조회 빈 데이터 처리 개선

## 변경 사항
- `IndexDataController` - PATCH `/{id}` 엔드포인트의 `@RequestBody`에 `@Valid` 추가
  - `@Valid` 누락으로 `@PositiveOrZero` 등 유효성 검증이 실행되지 않으므로 `@Valid` 추가로 잘못된 입력값(음수 등)에 대해 400 에러 정상 반환
- `IndexDataService` - `getPerformanceRank()` 빈 데이터 처리 방식 변경
  - 기존: 지수 데이터가 없을 때 `IllegalStateException("지수 데이터가 없습니다.")` 발생 → 500 에러
  - 변경: 데이터 없을 경우 빈 리스트 `[]` 반환 → 200 OK

Closes #48 
