### PR TITLE
fix: 비교 데이터 없이 관심 지수 성과 포함되게 수정

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import java.util.Optional;
 import com.codeit.findex.domain.indexdata.dto.request.IndexDataCreateRequest;
 import jakarta.persistence.EntityNotFoundException;
-
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -115,25 +113,26 @@ public class IndexDataService {
       LocalDate targetDate = getTargetDate(latest.getBaseDate(), performancePeriodType);
       IndexData compareData = findCompareData(indexDataList, targetDate);
 
-      if (compareData == null
-          || compareData.getClosingPrice() == null
-          || compareData.getBaseDate() == null) {
-        continue;
-      }
-
       BigDecimal currentPrice = latest.getClosingPrice();
-      BigDecimal beforePrice = compareData.getClosingPrice();
-      BigDecimal versus = currentPrice.subtract(beforePrice);
-
+      BigDecimal beforePrice = null;
+      BigDecimal versus = null;
       BigDecimal fluctuationRate = null;
-      if (beforePrice.compareTo(BigDecimal.ZERO) != 0) {
-        fluctuationRate =
-            versus
-                .divide(beforePrice, 6, RoundingMode.HALF_UP)
-                .multiply(BigDecimal.valueOf(100))
-                .setScale(2, RoundingMode.HALF_UP);
+
+      // 과거 데이터가 존재할 때만 대비(versus)와 등락률(fluctuationRate) 계산
+      if (compareData != null && compareData.getClosingPrice() != null) {
+        beforePrice = compareData.getClosingPrice();
+        versus = currentPrice.subtract(beforePrice);
+
+        if (beforePrice.compareTo(BigDecimal.ZERO) != 0) {
+          fluctuationRate =
+              versus
+                  .divide(beforePrice, 6, RoundingMode.HALF_UP)
+                  .multiply(BigDecimal.valueOf(100))
+                  .setScale(2, RoundingMode.HALF_UP);
+        }
       }
 
+      // 과거 데이터가 없어서 versus 등이 null이더라도 일단 응답 리스트에는 무조건 추가
       responses.add(
           indexDataMapper.toIndexDataFavoriteResponse(
               latest, versus, fluctuationRate, currentPrice, beforePrice));


### PR DESCRIPTION
## 변경사항
- 비교 데이터가 없는 경우에도 관심 지수(즐겨찾기) 성과 목록에서 항목이 누락되지 않도록 수정했습니다.

## 변경 전
- 기존에는 비교 대상 데이터가 없으면 해당 지수를 응답에서 제외했습니다.

## 변경 후
- 변경 후에는 최신 데이터 기준으로 항목을 반환하고, 비교값은 null로 내려 프론트에서 처리(0으로 처리됨)할 수 있게 했습니다. 