### PR TITLE
docs: syncjob, autosyncconfig 응답 조정

### DIFF
--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/controller/AutoSyncConfigController.java
@@ -5,12 +5,16 @@ import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigPageResponse;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigResponse;
 import com.codeit.findex.domain.autosyncconfig.dto.AutoSyncConfigUpdateRequest;
 import com.codeit.findex.domain.autosyncconfig.service.AutoSyncConfigService;
+import com.codeit.findex.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -27,35 +31,73 @@ public class AutoSyncConfigController {
 
   private final AutoSyncConfigService autoSyncConfigService;
 
-  @Operation(summary = "자동 연동 설정 목록 조회",
+  @Operation(
+      summary = "자동 연동 설정 목록 조회",
       description = "자동 연동 설정 목록을 조회합니다. 필터링, 정렬, 커서 기반 페이지네이션을 지원합니다.",
       operationId = "getAutoSyncConfigList")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "자동 연동 설정 목록 조회 성공"),
-      @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필터 값 등)"),
-      @ApiResponse(responseCode = "500", description = "서버 오류")
-  })
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "자동 연동 설정 목록 조회 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = AutoSyncConfigPageResponse.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (유효하지 않은 필터 값 등)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)))
+      })
   @GetMapping
   public ResponseEntity<AutoSyncConfigPageResponse> getAutoSyncConfigs(
-      @Valid AutoSyncConfigListRequest request) {
+      @ParameterObject @Valid AutoSyncConfigListRequest request) {
     AutoSyncConfigPageResponse response = autoSyncConfigService.getAutoSyncConfigs(request);
     return ResponseEntity.ok(response);
   }
 
-  @Operation(summary = "자동 연동 설정 수정",
+  @Operation(
+      summary = "자동 연동 설정 수정",
       description = "기존 자동 연동 설정을 수정합니다.",
       operationId = "updateAutoSyncConfig")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "자동 연동 설정 수정 성공"),
-      @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 설정 값 등)"),
-      @ApiResponse(responseCode = "404", description = "수정할 자동 연동 설정을 찾을 수 없음"),
-      @ApiResponse(responseCode = "500", description = "서버 오류")
-  })
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "자동 연동 설정 수정 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = AutoSyncConfigResponse.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (유효하지 않은 설정 값 등)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "수정할 자동 연동 설정을 찾을 수 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)))
+      })
   @PatchMapping("/{id}")
   public ResponseEntity<AutoSyncConfigResponse> updateAutoSyncConfig(
       @PathVariable Long id,
-      @RequestBody @Valid AutoSyncConfigUpdateRequest request
-  ) {
+      @RequestBody @Valid AutoSyncConfigUpdateRequest request) {
     AutoSyncConfigResponse response =
         autoSyncConfigService.updateAutoSyncConfig(id, request);
     return ResponseEntity.ok(response);

--- a/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigListRequest.java
+++ b/src/main/java/com/codeit/findex/domain/autosyncconfig/dto/AutoSyncConfigListRequest.java
@@ -1,18 +1,26 @@
 package com.codeit.findex.domain.autosyncconfig.dto;
 
-import jakarta.validation.constraints.Min;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 
 public record AutoSyncConfigListRequest(
+    @Schema(description = "지수 정보 ID", example = "1")
     Long indexInfoId,
+    @Schema(description = "활성화 여부", example = "true")
     Boolean enabled,
+    @Schema(description = "이전 페이지 마지막 요소 ID", example = "10")
     Long idAfter,
+    @Schema(description = "커서 (다음 페이지 시작점)", example = "KOSPI 200")
     String cursor,
+    @Schema(description = "정렬 필드", example = "indexInfo.indexName", defaultValue = "indexInfo.indexName")
     @Pattern(regexp = "^(indexInfo.indexName|enabled)$")
     String sortField,
+    @Schema(description = "정렬 방향", example = "asc", defaultValue = "asc")
     @Pattern(regexp = "^(asc|desc)$")
     String sortDirection,
-    @Min(1)
+    @Schema(description = "페이지 크기", example = "10", defaultValue = "10")
+    @Positive
     Integer size
 ) {
 

--- a/src/main/java/com/codeit/findex/domain/syncjob/controller/SyncJobController.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/controller/SyncJobController.java
@@ -1,25 +1,29 @@
 package com.codeit.findex.domain.syncjob.controller;
 
-import com.codeit.findex.domain.syncjob.dto.indexinfo.IndexInfoSyncJobResponse;
 import com.codeit.findex.domain.syncjob.dto.SyncJobListRequest;
 import com.codeit.findex.domain.syncjob.dto.SyncJobPageResponse;
 import com.codeit.findex.domain.syncjob.dto.indexdata.IndexDataSyncJobResponse;
 import com.codeit.findex.domain.syncjob.dto.indexdata.SyncIndexDataRequest;
+import com.codeit.findex.domain.syncjob.dto.indexinfo.IndexInfoSyncJobResponse;
 import com.codeit.findex.domain.syncjob.service.SyncJobService;
+import com.codeit.findex.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,9 +41,24 @@ public class SyncJobController {
       operationId = "syncIndexInfos")
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "202", description = "연동 작업 생성 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-        @ApiResponse(responseCode = "500", description = "서버 오류")
+        @ApiResponse(
+            responseCode = "202",
+            description = "연동 작업 생성 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = IndexInfoSyncJobResponse.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)))
       })
   @PostMapping("/index-infos")
   public ResponseEntity<List<IndexInfoSyncJobResponse>> syncIndexInfos(
@@ -55,10 +74,30 @@ public class SyncJobController {
       operationId = "syncIndexData")
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "202", description = "연동 작업 생성 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-        @ApiResponse(responseCode = "404", description = "지수 정보를 찾을 수 없음"),
-        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        @ApiResponse(
+            responseCode = "202",
+            description = "연동 작업 생성 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = IndexDataSyncJobResponse.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "지수 정보를 찾을 수 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)))
       })
   @PostMapping("/index-data")
   public ResponseEntity<List<IndexDataSyncJobResponse>> syncIndexData(
@@ -71,17 +110,34 @@ public class SyncJobController {
     return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
   }
 
-  @Operation(summary = "연동 작업 목록 조회",
+  @Operation(
+      summary = "연동 작업 목록 조회",
       description = "연동 작업 목록을 조회합니다. 필터링, 정렬, 커서 기반 페이지네이션을 지원합니다.",
       operationId = "getSyncJobList")
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "200", description = "자동 연동 설정 목록 조회 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필터 값 등)"),
-        @ApiResponse(responseCode = "500", description = "서버 오류")
+        @ApiResponse(
+            responseCode = "200",
+            description = "연동 작업 목록 조회 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = SyncJobPageResponse.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (유효하지 않은 필터 값 등)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)))
       })
   @GetMapping
-  public ResponseEntity<SyncJobPageResponse> getSyncjobs(@Valid SyncJobListRequest request) {
+  public ResponseEntity<SyncJobPageResponse> getSyncjobs(
+      @ParameterObject @Valid SyncJobListRequest request) {
     SyncJobPageResponse response = syncJobService.getSyncJobs(request);
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/codeit/findex/domain/syncjob/controller/SyncJobController.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/controller/SyncJobController.java
@@ -41,24 +41,24 @@ public class SyncJobController {
       operationId = "syncIndexInfos")
   @ApiResponses(
       value = {
-        @ApiResponse(
-            responseCode = "202",
-            description = "연동 작업 생성 성공",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = IndexInfoSyncJobResponse.class))),
-        @ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = ErrorResponse.class))),
-        @ApiResponse(
-            responseCode = "500",
-            description = "서버 오류",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = ErrorResponse.class)))
+          @ApiResponse(
+              responseCode = "200",
+              description = "연동 작업 생성 성공",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = IndexInfoSyncJobResponse.class))),
+          @ApiResponse(
+              responseCode = "400",
+              description = "잘못된 요청",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+              responseCode = "500",
+              description = "서버 오류",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = ErrorResponse.class)))
       })
   @PostMapping("/index-infos")
   public ResponseEntity<List<IndexInfoSyncJobResponse>> syncIndexInfos(
@@ -74,30 +74,30 @@ public class SyncJobController {
       operationId = "syncIndexData")
   @ApiResponses(
       value = {
-        @ApiResponse(
-            responseCode = "202",
-            description = "연동 작업 생성 성공",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = IndexDataSyncJobResponse.class))),
-        @ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = ErrorResponse.class))),
-        @ApiResponse(
-            responseCode = "404",
-            description = "지수 정보를 찾을 수 없음",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = ErrorResponse.class))),
-        @ApiResponse(
-            responseCode = "500",
-            description = "서버 내부 오류",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = ErrorResponse.class)))
+          @ApiResponse(
+              responseCode = "200",
+              description = "연동 작업 생성 성공",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = IndexDataSyncJobResponse.class))),
+          @ApiResponse(
+              responseCode = "400",
+              description = "잘못된 요청",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+              responseCode = "404",
+              description = "지수 정보를 찾을 수 없음",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+              responseCode = "500",
+              description = "서버 내부 오류",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = ErrorResponse.class)))
       })
   @PostMapping("/index-data")
   public ResponseEntity<List<IndexDataSyncJobResponse>> syncIndexData(
@@ -116,24 +116,24 @@ public class SyncJobController {
       operationId = "getSyncJobList")
   @ApiResponses(
       value = {
-        @ApiResponse(
-            responseCode = "200",
-            description = "연동 작업 목록 조회 성공",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = SyncJobPageResponse.class))),
-        @ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청 (유효하지 않은 필터 값 등)",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = ErrorResponse.class))),
-        @ApiResponse(
-            responseCode = "500",
-            description = "서버 오류",
-            content = @Content(
-                mediaType = "*/*",
-                schema = @Schema(implementation = ErrorResponse.class)))
+          @ApiResponse(
+              responseCode = "200",
+              description = "연동 작업 목록 조회 성공",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = SyncJobPageResponse.class))),
+          @ApiResponse(
+              responseCode = "400",
+              description = "잘못된 요청 (유효하지 않은 필터 값 등)",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(
+              responseCode = "500",
+              description = "서버 오류",
+              content = @Content(
+                  mediaType = "*/*",
+                  schema = @Schema(implementation = ErrorResponse.class)))
       })
   @GetMapping
   public ResponseEntity<SyncJobPageResponse> getSyncjobs(

--- a/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobListRequest.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/dto/SyncJobListRequest.java
@@ -3,6 +3,7 @@ package com.codeit.findex.domain.syncjob.dto;
 import com.codeit.findex.domain.common.enums.JobType;
 import com.codeit.findex.domain.common.enums.SyncResult;
 import com.codeit.findex.domain.syncjob.validation.ValidSyncJobDateRange;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
@@ -10,22 +11,34 @@ import java.time.LocalDateTime;
 
 @ValidSyncJobDateRange
 public record SyncJobListRequest(
+    @Schema(description = "연동 작업 유형", example = "INDEX_DATA")
     JobType jobType,
+    @Schema(description = "지수 정보 ID", example = "1")
     Long indexInfoId,
+    @Schema(description = "대상 날짜 (부터)", example = "2026-04-01")
     LocalDate baseDateFrom,
+    @Schema(description = "대상 날짜 (까지)", example = "2026-04-21")
     LocalDate baseDateTo,
+    @Schema(description = "작업자", example = "127.0.0.1")
     String worker,
+    @Schema(description = "작업 일시 (부터)", example = "2026-04-21T10:00:00")
     LocalDateTime jobTimeFrom,
+    @Schema(description = "작업 일시 (까지)", example = "2026-04-21T23:59:59")
     LocalDateTime jobTimeTo,
+    @Schema(description = "작업 상태", example = "SUCCESS")
     SyncResult status,
+    @Schema(description = "이전 페이지 마지막 요소 ID", example = "10")
     Long idAfter,
+    @Schema(description = "커서 (다음 페이지 시작점)", example = "2026-04-21T10:30:00")
     String cursor,
+    @Schema(description = "정렬 필드", example = "jobTime", defaultValue = "jobTime")
     @Pattern(regexp = "^(targetDate|jobTime)$")
     String sortField,
+    @Schema(description = "정렬 방향", example = "desc", defaultValue = "desc")
     @Pattern(regexp = "^(asc|desc)$")
     String sortDirection,
+    @Schema(description = "페이지 크기", example = "10", defaultValue = "10")
     @Positive
     Integer size
 ) {
-
 }

--- a/src/main/java/com/codeit/findex/domain/syncjob/dto/indexdata/SyncIndexDataRequest.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/dto/indexdata/SyncIndexDataRequest.java
@@ -1,11 +1,15 @@
 package com.codeit.findex.domain.syncjob.dto.indexdata;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
 
 public record SyncIndexDataRequest(
+    @Schema(description = "지수 정보 ID 목록 (비어 있을 경우 모든 지수 대상)", example = "[1,2,3]")
     List<Long> indexInfoIds,
+    @Schema(description = "대상 날짜 (부터)", example = "2026-04-01")
     @NotNull LocalDate baseDateFrom,
+    @Schema(description = "대상 날짜 (까지)", example = "2026-04-21")
     @NotNull LocalDate baseDateTo
 ) {}


### PR DESCRIPTION
## 작업 내용
`syncjob`, `autosyncconfig` 도메인에 대한 OpenAPI/Swagger 문서 형식을 프로젝트 명세에 맞추었습니다.

## 변경 사항

- `syncjob`, `autosyncconfig` 컨트롤러의 실패 응답(`400/404/500`)을 `ErrorResponse`로 명시했습니다.
- `GET /api/sync-jobs`, `GET /api/auto-sync-configs`에서 요청 DTO가 `request` 객체 한 덩어리로 보이지 않도록 `@ParameterObject`를 적용했습니다.
- `SyncJobListRequest`, `AutoSyncConfigListRequest`, `SyncIndexDataRequest`에 `@Schema` 설명, 예시값, 기본값을 추가해 명세와 Swagger 노출 형식을 맞췄습니다.
- `syncjob` 목록 조회 응답 설명 문구 중 잘못된 문구를 함께 정리했습니다.

## 테스트
- [x] 로컬 테스트 여부
- [x] 컨벤션 부합 여부

## ETC
- 실제 비즈니스 로직은 변경하지 않았고, 문서화 및 Swagger 노출 형식 위주로만 수정했습니다.