### PR TITLE
fix: API 명세에 맞는 코드 수정 및 지수차트, 랭킹 문제 개선

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexDataUpdateRequest.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexDataUpdateRequest.java
@@ -1,12 +1,9 @@
 package com.codeit.findex.domain.indexdata.dto.request;
 
-import com.codeit.findex.domain.common.enums.SourceType;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 
 public record IndexDataUpdateRequest(
-    SourceType sourceType,       // 수집 출처
     @PositiveOrZero(message = "시가는 0 이상이어야 합니다.") BigDecimal marketPrice,
     @PositiveOrZero(message = "종가는 0 이상이어야 합니다.") BigDecimal closingPrice,
     @PositiveOrZero(message = "고가는 0 이상이어야 합니다.") BigDecimal highPrice,

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexPerformanceRankRequest.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexPerformanceRankRequest.java
@@ -2,7 +2,6 @@ package com.codeit.findex.domain.indexdata.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record IndexPerformanceRankRequest(
@@ -10,13 +9,22 @@ public record IndexPerformanceRankRequest(
     @Positive(message = "지수 정보 ID는 양수여야 합니다.")
     Long indexInfoId,
 
-    @Schema(description = "성과 비교 기간 유형", example = "DAILY")
-    @NotNull(message = "기간 유형은 필수입니다.")
+    @Schema(description = "성과 비교 기간 유형", example = "DAILY", defaultValue = "DAILY")
     UnitPeriodType periodType,
 
-    @Schema(description = "반환할 랭킹 개수", example = "10")
+    @Schema(description = "반환할 랭킹 개수", example = "10", defaultValue = "10")
     @Min(value = 1, message = "랭킹 개수는 1 이상이어야 합니다.")
     Integer limit
 ) {
+    private static final UnitPeriodType DEFAULT_PERIOD_TYPE = UnitPeriodType.DAILY;
+    private static final int DEFAULT_LIMIT = 10;
 
+    public IndexPerformanceRankRequest {
+        if (periodType == null) {
+            periodType = DEFAULT_PERIOD_TYPE;
+        }
+        if (limit == null) {
+            limit = DEFAULT_LIMIT;
+        }
+    }
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/entity/IndexData.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/entity/IndexData.java
@@ -116,6 +116,30 @@ public class IndexData {
   }
 
   public void update(
+      BigDecimal marketPrice,
+      BigDecimal closingPrice,
+      BigDecimal highPrice,
+      BigDecimal lowPrice,
+      BigDecimal versus,
+      BigDecimal fluctuationRate,
+      Long tradingQuantity,
+      Long tradingPrice,
+      Long marketTotalAmount
+  ) {
+    update(
+        this.sourceType,
+        marketPrice,
+        closingPrice,
+        highPrice,
+        lowPrice,
+        versus,
+        fluctuationRate,
+        tradingQuantity,
+        tradingPrice,
+        marketTotalAmount);
+  }
+
+  public void update(
       SourceType sourceType,
       BigDecimal marketPrice,
       BigDecimal closingPrice,
@@ -127,15 +151,15 @@ public class IndexData {
       Long tradingPrice,
       Long marketTotalAmount
   ) {
-      this.sourceType = sourceType;
-      this.marketPrice = marketPrice;
-      this.closingPrice = closingPrice;
-      this.highPrice = highPrice;
-      this.lowPrice = lowPrice;
-      this.versus = versus;
-      this.fluctuationRate = fluctuationRate;
-      this.tradingQuantity = tradingQuantity;
-      this.tradingPrice = tradingPrice;
-      this.marketTotalAmount = marketTotalAmount;
+    this.sourceType = sourceType;
+    this.marketPrice = marketPrice;
+    this.closingPrice = closingPrice;
+    this.highPrice = highPrice;
+    this.lowPrice = lowPrice;
+    this.versus = versus;
+    this.fluctuationRate = fluctuationRate;
+    this.tradingQuantity = tradingQuantity;
+    this.tradingPrice = tradingPrice;
+    this.marketTotalAmount = marketTotalAmount;
   }
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -321,7 +321,7 @@ public class IndexDataService {
     IndexData indexData =
         indexDataRepository
             .findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("해당 지수 데이터가 없습니다. id=" + id));
+            .orElseThrow(() -> new EntityNotFoundException("수정할 지수 데이터를 찾을 수 없습니다. id=" + id));
 
     indexData.update(
         request.marketPrice(),

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -249,7 +249,11 @@ public class IndexDataService {
             .findById(indexInfoId)
             .orElseThrow(() -> new IllegalArgumentException("해당 지수 정보가 없습니다. id=" + indexInfoId));
 
-    LocalDate endDate = LocalDate.now();
+    LocalDate endDate = indexDataRepository
+        .findFirstByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(indexInfoId, LocalDate.now())
+        .map(IndexData::getBaseDate)
+        .orElseGet(LocalDate::now);
+
     LocalDate startDate =
         switch (periodType) {
           case MONTHLY -> endDate.minusMonths(1);

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -38,8 +38,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class IndexDataService {
 
-  private static final int DEFAULT_RANK_LIMIT = 10;
-
   private final IndexDataRepository indexDataRepository;
   private final IndexInfoRepository indexInfoRepository;
   private final IndexDataMapper indexDataMapper;
@@ -185,9 +183,6 @@ public class IndexDataService {
   }
 
   private LocalDate getRankTargetDate(LocalDate currentDate, UnitPeriodType periodType) {
-    if (periodType == null) {
-      throw new IllegalArgumentException("기간 유형은 필수입니다.");
-    }
     return switch (periodType) {
       case DAILY -> currentDate.minusDays(1);
       case WEEKLY -> currentDate.minusWeeks(1);
@@ -242,9 +237,6 @@ public class IndexDataService {
   }
 
   private int resolveRankLimit(Integer limit) {
-    if (limit == null) {
-      return DEFAULT_RANK_LIMIT;
-    }
     if (limit < 1) {
       throw new IllegalArgumentException("랭킹 개수는 1 이상이어야 합니다.");
     }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -277,19 +277,33 @@ public class IndexDataService {
       BigDecimal ma5 = null;
       if (i >= 4) {
         BigDecimal sum5 = BigDecimal.ZERO;
+        int validCount5 = 0;
         for (int j = i - 4; j <= i; j++) {
-          sum5 = sum5.add(fetchedData.get(j).getClosingPrice());
+          BigDecimal price = fetchedData.get(j).getClosingPrice();
+          if (price != null) {
+            sum5 = sum5.add(price);
+            validCount5++;
+          }
         }
-        ma5 = sum5.divide(BigDecimal.valueOf(5), 2, RoundingMode.HALF_UP);
+        if (validCount5 > 0) {
+          ma5 = sum5.divide(BigDecimal.valueOf(validCount5), 2, RoundingMode.HALF_UP);
+        }
       }
 
       BigDecimal ma20 = null;
       if (i >= 19) {
         BigDecimal sum20 = BigDecimal.ZERO;
+        int validCount20 = 0;
         for (int j = i - 19; j <= i; j++) {
-          sum20 = sum20.add(fetchedData.get(j).getClosingPrice());
+          BigDecimal price = fetchedData.get(j).getClosingPrice();
+          if (price != null) {
+            sum20 = sum20.add(price);
+            validCount20++;
+          }
         }
-        ma20 = sum20.divide(BigDecimal.valueOf(20), 2, RoundingMode.HALF_UP);
+        if (validCount20 > 0) {
+          ma20 = sum20.divide(BigDecimal.valueOf(validCount20), 2, RoundingMode.HALF_UP);
+        }
       }
 
       if (!currentDate.isBefore(startDate)) {

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -324,7 +324,6 @@ public class IndexDataService {
             .orElseThrow(() -> new IllegalArgumentException("해당 지수 데이터가 없습니다. id=" + id));
 
     indexData.update(
-        request.sourceType(),
         request.marketPrice(),
         request.closingPrice(),
         request.highPrice(),

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -261,7 +261,7 @@ public class IndexDataService {
           case YEARLY -> endDate.minusYears(1);
         };
 
-    LocalDate fetchStartDate = startDate.minusDays(40);
+    LocalDate fetchStartDate = startDate.minusDays(60);
     List<IndexData> fetchedData =
         indexDataRepository.findByIndexInfoIdAndBaseDateBetweenOrderByBaseDateAsc(
             indexInfoId, fetchStartDate, endDate);


### PR DESCRIPTION
## 작업 내용
- API 명세와 맞게 수정 및 차트,랭킹 문제 해결

## 변경 사항
- 지수 데이터 수정 요청 DTO에서 명세에 없는 sourceType 제거하였습니다.
- 수정 대상 지수 데이터가 없을 때 404 응답을 반환하도록 예외 처리 변경하였습니다.
- 지수 성과 랭킹 조회 요청 기본값 처리 개선하였습니다.
- 차트 오늘 날짜 기준 조회할 때 dataPodins가 비어있는 문제 해결하였습니다.
- closingPrice가 null인 경우 NullPointerException 위험 문제 해결하였습니다.
- 차트 버퍼 기간 40 -> 60일로 연장하였습니다.

Closes #55
