### PR TITLE
feat: 지수 데이터 CSV export

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
@@ -4,6 +4,7 @@ import com.codeit.findex.domain.common.enums.PerformancePeriodType;
 import com.codeit.findex.domain.indexdata.dto.IndexDataFavoriteResponse;
 import com.codeit.findex.domain.indexdata.dto.IndexDataSearchCondition;
 import com.codeit.findex.domain.indexdata.dto.request.IndexChartRequest;
+import com.codeit.findex.domain.indexdata.dto.request.IndexDataExportCSVRequest;
 import com.codeit.findex.domain.indexdata.dto.request.IndexDataUpdateRequest;
 import com.codeit.findex.domain.indexdata.dto.request.IndexPerformanceRankRequest;
 import com.codeit.findex.domain.indexdata.dto.response.IndexChartResponse;
@@ -11,15 +12,20 @@ import com.codeit.findex.domain.indexdata.dto.response.IndexDataResponse;
 import com.codeit.findex.domain.indexdata.dto.response.RankedIndexPerformanceResponse;
 import com.codeit.findex.domain.indexdata.service.IndexDataService;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCursorResponse;
+import com.codeit.findex.global.error.exception.FileDownloadException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import com.codeit.findex.domain.indexdata.dto.request.IndexDataCreateRequest;
@@ -94,31 +100,45 @@ public class IndexDataController {
     return ResponseEntity.ok(indexDataService.getChart(id, request.periodType()));
   }
 
-
-
-  @Operation(
-          summary = "지수 데이터 등록",
-          description = "새로운 지수 데이터를 등록합니다."
-  )
+  @Operation(summary = "지수 데이터 등록", description = "새로운 지수 데이터를 등록합니다.")
   @PostMapping
   public ResponseEntity<IndexDataResponse> create(
-          @Valid @RequestBody IndexDataCreateRequest request
-  ) {
+      @Valid @RequestBody IndexDataCreateRequest request) {
     IndexDataResponse response = indexDataService.create(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
-  @Operation(
-          summary = "지수 데이터 삭제",
-          description = "특정 지수 데이터를 삭제합니다."
-  )
+  @Operation(summary = "지수 데이터 삭제", description = "특정 지수 데이터를 삭제합니다.")
   @DeleteMapping("/{id}")
-  public ResponseEntity<Void> delete(
-          @Parameter(description = "지수 데이터 ID") @PathVariable Long id
-  ) {
+  public ResponseEntity<Void> delete(@Parameter(description = "지수 데이터 ID") @PathVariable Long id) {
     indexDataService.delete(id);
     return ResponseEntity.noContent().build();
   }
 
+  @Operation(
+      summary = "지수 데이터 CSV export",
+      description = "지수 데이터를 CSV 파일로 export합니다.",
+      operationId = "downloadIndexData")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "CSV 파일 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필터 값 등)"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+      })
+  @GetMapping("/export/csv")
+  public void downloadIndexData(
+      @Valid @ModelAttribute IndexDataExportCSVRequest request, HttpServletResponse response) {
+    String fileName = "index-data-" + LocalDate.now() + ".csv";
 
+    // csv 파일임을 알리고 다운로드 팝업을 띄워서 파일로 저장하라는 의미
+    response.setContentType("text/csv; charset=UTF-8");
+    response.setHeader(
+        HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"");
+
+    try {
+      indexDataService.exportToCSV(request, response.getWriter());
+    } catch (IOException e) {
+      throw new FileDownloadException("다운로드에 실패하였습니다.", e);
+    }
+  }
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexDataExportCSVRequest.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/request/IndexDataExportCSVRequest.java
@@ -1,0 +1,26 @@
+package com.codeit.findex.domain.indexdata.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record IndexDataExportCSVRequest(
+    Long indexInfoId,
+    @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+    @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
+    @Pattern(
+            regexp =
+                "^(baseDate|marketPrice|closingPrice|highPrice|lowPrice|versus|fluctuationRate|tradingQuantity|tradingPrice|marketTotalAmount)$",
+            message = "올바른 정렬 필드가 아닙니다.")
+        String sortField,
+    @Pattern(regexp = "^(?i)(asc|desc)$", message = "정렬 방향은 asc 또는 desc만 가능합니다.")
+        String sortDirection) {
+  public IndexDataExportCSVRequest {
+    if (sortField == null || sortField.isBlank()) {
+      sortField = "baseDate";
+    }
+    if (sortDirection == null || sortDirection.isBlank()) {
+      sortDirection = "desc";
+    }
+  }
+}

--- a/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepositoryCustom.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.codeit.findex.domain.indexdata.repository;
 
 import com.codeit.findex.domain.indexdata.dto.IndexDataSearchCondition;
+import com.codeit.findex.domain.indexdata.dto.request.IndexDataExportCSVRequest;
 import com.codeit.findex.domain.indexdata.entity.IndexData;
 
 import java.util.List;
@@ -12,4 +13,7 @@ public interface IndexDataRepositoryCustom {
 
   // 2. 조건에 맞는 전체 지수 데이터의 개수를 세는 메서드 (hasNext와 별개로 전체 페이지/개수 정보 제공용)
   long countByCondition(IndexDataSearchCondition condition);
+
+  // 조건에 맞는 지수 데이터 목록 전체를 CSV 파일로 export하기 위한 메서드
+  List<IndexData> findAllForExport(IndexDataExportCSVRequest request);
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepositoryImpl.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/repository/IndexDataRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.codeit.findex.domain.indexdata.repository;
 
 import com.codeit.findex.domain.indexdata.dto.IndexDataSearchCondition;
+import com.codeit.findex.domain.indexdata.dto.request.IndexDataExportCSVRequest;
 import com.codeit.findex.domain.indexdata.entity.IndexData;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -28,7 +29,9 @@ public class IndexDataRepositoryImpl implements IndexDataRepositoryCustom {
             eqIndexInfoId(condition.indexInfoId()),
             betweenDates(condition.startDate(), condition.endDate()),
             getCursorCondition(condition))
-        .orderBy(createOrderSpecifier(condition), indexData.id.asc())
+        .orderBy(
+            createOrderSpecifier(condition.sortField(), condition.getSortDirection()),
+            indexData.id.asc())
         .limit(condition.getSize() + 1)
         .fetch();
   }
@@ -44,6 +47,18 @@ public class IndexDataRepositoryImpl implements IndexDataRepositoryCustom {
                 betweenDates(condition.startDate(), condition.endDate()))
             .fetchOne();
     return count != null ? count : 0L;
+  }
+
+  @Override
+  public List<IndexData> findAllForExport(IndexDataExportCSVRequest request) {
+    return queryFactory
+        .selectFrom(indexData)
+        .where(
+            eqIndexInfoId(request.indexInfoId()),
+            betweenDates(request.startDate(), request.endDate()))
+        .orderBy(
+            createOrderSpecifier(request.sortField(), request.sortDirection()), indexData.id.asc())
+        .fetch();
   }
 
   private BooleanExpression eqIndexInfoId(Long indexInfoId) {
@@ -143,11 +158,11 @@ public class IndexDataRepositoryImpl implements IndexDataRepositoryCustom {
         : path.lt(cursorValue).or(path.eq(cursorValue).and(indexData.id.gt(idAfter)));
   }
 
-  // 정렬 도우미
-  private OrderSpecifier<?> createOrderSpecifier(IndexDataSearchCondition condition) {
-    Order direction = condition.getSortDirection().equals("asc") ? Order.ASC : Order.DESC;
+  // 정렬 도우미 (목록 조회 & CSV 공통 사용)
+  private OrderSpecifier<?> createOrderSpecifier(String sortField, String sortDirection) {
+    Order direction = sortDirection.equalsIgnoreCase("asc") ? Order.ASC : Order.DESC;
 
-    return switch (condition.getSortField()) {
+    return switch (sortField) {
       case "marketPrice" -> new OrderSpecifier<>(direction, indexData.marketPrice);
       case "closingPrice" -> new OrderSpecifier<>(direction, indexData.closingPrice);
       case "highPrice" -> new OrderSpecifier<>(direction, indexData.highPrice);

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -4,6 +4,7 @@ import com.codeit.findex.domain.common.enums.PerformancePeriodType;
 import com.codeit.findex.domain.indexdata.dto.IndexDataFavoriteResponse;
 import com.codeit.findex.domain.indexdata.dto.IndexDataMapper;
 import com.codeit.findex.domain.indexdata.dto.IndexDataSearchCondition;
+import com.codeit.findex.domain.indexdata.dto.request.IndexDataExportCSVRequest;
 import com.codeit.findex.domain.indexdata.dto.request.IndexDataUpdateRequest;
 import com.codeit.findex.domain.indexdata.dto.request.IndexPerformanceRankRequest;
 import com.codeit.findex.domain.indexdata.dto.request.PeriodType;
@@ -18,6 +19,9 @@ import com.codeit.findex.domain.indexdata.repository.IndexDataRepository;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCursorResponse;
 import com.codeit.findex.domain.indexinfo.entity.IndexInfo;
 import com.codeit.findex.domain.indexinfo.repository.IndexInfoRepository;
+import com.codeit.findex.global.error.exception.FileDownloadException;
+import java.io.IOException;
+import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
@@ -366,5 +370,38 @@ public class IndexDataService {
             .orElseThrow(() -> new EntityNotFoundException("삭제할 지수 데이터를 찾을 수 없습니다. ID: " + id));
 
     indexDataRepository.delete(indexData);
+  }
+
+  public void exportToCSV(IndexDataExportCSVRequest request, Writer writer) {
+    try {
+      // 파일을 UTF-8로 인코딩 하라는 의미
+      writer.write("\uFEFF");
+
+      writer.write("기준일자,시가,종가,고가,저가,전일대비등락,등락률,거래량,거래대금,시가총액\n");
+
+      List<IndexData> indexDataList = indexDataRepository.findAllForExport(request);
+
+      for (IndexData data : indexDataList) {
+        StringBuilder row = new StringBuilder();
+
+        row.append(data.getBaseDate() != null ? data.getBaseDate() : "").append(",");
+        row.append(data.getMarketPrice() != null ? data.getMarketPrice().toPlainString() : "").append(",");
+        row.append(data.getClosingPrice() != null ? data.getClosingPrice().toPlainString() : "").append(",");
+        row.append(data.getHighPrice() != null ? data.getHighPrice().toPlainString() : "").append(",");
+        row.append(data.getLowPrice() != null ? data.getLowPrice().toPlainString() : "").append(",");
+        row.append(data.getVersus() != null ? data.getVersus().toPlainString() : "").append(",");
+        row.append(data.getFluctuationRate() != null ? data.getFluctuationRate().toPlainString() : "").append(",");
+        row.append(data.getTradingQuantity() != null ? data.getTradingQuantity() : "").append(",");
+        row.append(data.getTradingPrice() != null ? data.getTradingPrice() : "").append(",");
+        row.append(data.getMarketTotalAmount() != null ? data.getMarketTotalAmount() : "");
+
+        row.append("\n");
+
+        writer.write(row.toString());
+      }
+      writer.flush();
+    } catch (IOException e) {
+      throw new FileDownloadException("다운로드에 실패하였습니다.", e);
+    }
   }
 }

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -381,6 +381,11 @@ public class IndexDataService {
 
       List<IndexData> indexDataList = indexDataRepository.findAllForExport(request);
 
+      // 데이터가 없을 경우 다운로드를 못하도록 방어
+      if (indexDataList.isEmpty()) {
+        throw new FileDownloadException("조건에 맞는 다운로드 데이터가 존재하지 않습니다.");
+      }
+
       for (IndexData data : indexDataList) {
         StringBuilder row = new StringBuilder();
 

--- a/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/findex/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.codeit.findex.global.error;
 
+import com.codeit.findex.global.error.exception.FileDownloadException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -44,10 +45,12 @@ public class GlobalExceptionHandler {
         e.getBindingResult().getFieldErrors().stream()
             .findFirst() // field Errors 먼저 확인
             .map(error -> error.getField() + ": " + error.getDefaultMessage())
-            .orElseGet(() -> e.getBindingResult().getGlobalErrors().stream()
-                .findFirst() // 없다면, globalErrors 확인
-                .map(error -> error.getDefaultMessage())
-                .orElse("요청값이 올바르지 않습니다.")); // 둘 다 없다면, 기본 문구 사용
+            .orElseGet(
+                () ->
+                    e.getBindingResult().getGlobalErrors().stream()
+                        .findFirst() // 없다면, globalErrors 확인
+                        .map(error -> error.getDefaultMessage())
+                        .orElse("요청값이 올바르지 않습니다.")); // 둘 다 없다면, 기본 문구 사용
 
     ErrorResponse response =
         ErrorResponse.builder()
@@ -76,6 +79,21 @@ public class GlobalExceptionHandler {
             .build();
 
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  // 파일 다운로드 전용 커스텀 예외 생성
+  @ExceptionHandler(FileDownloadException.class)
+  public ResponseEntity<ErrorResponse> handlerFileDownloadException(FileDownloadException e) {
+    log.error("CSV 다운로드 실패: ", e);
+
+    ErrorResponse response =
+        ErrorResponse.builder()
+            .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+            .message("파일 다운로드 중 오류가 발생했습니다.")
+            .details(e.getMessage())
+            .build();
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
   }
 
   // 500 에러

--- a/src/main/java/com/codeit/findex/global/error/exception/FileDownloadException.java
+++ b/src/main/java/com/codeit/findex/global/error/exception/FileDownloadException.java
@@ -1,6 +1,10 @@
 package com.codeit.findex.global.error.exception;
 
-public class FileDownloadException extends RuntimeException{
+public class FileDownloadException extends RuntimeException {
+  public FileDownloadException(String message) {
+    super(message);
+  }
+
   public FileDownloadException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/com/codeit/findex/global/error/exception/FileDownloadException.java
+++ b/src/main/java/com/codeit/findex/global/error/exception/FileDownloadException.java
@@ -1,0 +1,7 @@
+package com.codeit.findex.global.error.exception;
+
+public class FileDownloadException extends RuntimeException{
+  public FileDownloadException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
## 작업 내용
지수 데이터를 CSV 파일로 export합니다.

## 변경 사항
- **CSV Export 전용 API 및 DTO 구현**: 지수 ID, 날짜 범위 및 10가지 필드에 대한 동적 정렬 조건을 지원하는 IndexDataExportCSVRequest를 추가했습니다.
- **Service 계층 파일 스트리밍 로직**: `StringBuilder`와 `Writer`를 활용해 메모리 효율을 극대화하고, 엑셀 한글 깨짐 방지를 위한 **UTF-8 BOM** 및 `BigDecimal` 필드에 지수 표현식 방지 로직(`toPlainString`)을 적용하였습니다.
- **Querydsl 기반 동적 조회**: 검색 조건에 부합하는 전체 데이터를 조회하는 `findAllForExport` 쿼리를 추가하였습니다.
- **정렬 로직 공통화**: 기존에 지수 데이터 목록을 페이징하는데 사용되던 `createOrderSpecifier` 정렬 도우미 메서드의 재사용성을 높이기 위해 파라미터를 변경하였습니다.
- **커스텀 예외 처리 시스템**: 다운로드 중 발생할 수 있는 오류를 추적하기 위해 `FileDownloadException` 클래스를 만들고 `GlobalExceptionHandler` 에 핸들러를 작성하여 에러 메시지와 로깅 메시지를 추가했습니다.
  - 범용적인 IOException이나 RuntimeException을 그대로 사용할 경우, 다른 비즈니스 로직 에러와 혼재되어 정확한 원인 파악이 어렵다는 점을 고려하여 전용 예외 클래스를 생성하였는데, 의견 부탁드립니다.
- **빈 데이터 다운로드 방어**: 검색 결과가 없을 경우 텅 빈 파일이 받아지는 대신 사용자에게 알림을 보낼 수 있도록 예외 방어 로직을 추가하였습니다. (프론트엔드에서 '다운로드에 실패하였습니다.' 라는 메시지를 내보내는 아쉬움이 있습니다.)

## 테스트
- [x] 로컬 테스트 여부 (로컬 환경 H2 데이터 기반 CSV 다운로드 및 정렬 일치 확인)
<img width="912" height="571" alt="image" src="https://github.com/user-attachments/assets/ae3b1bb0-23c8-4c72-8f01-a6fe7bdfc151" />
<img width="672" height="324" alt="image" src="https://github.com/user-attachments/assets/c112389c-977d-4ae4-944d-167ebf15eab8" />

- [x] 컨벤션 부합 여부

Closes #52 