### PR TITLE
fix: index-data 등록 버그 수정 및 자동 연동 목록 데이터 연관관계 넣기 수정

### DIFF
--- a/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/controller/IndexDataController.java
@@ -8,6 +8,7 @@ import com.codeit.findex.domain.indexdata.dto.request.IndexDataExportCSVRequest;
 import com.codeit.findex.domain.indexdata.dto.request.IndexDataUpdateRequest;
 import com.codeit.findex.domain.indexdata.dto.request.IndexPerformanceRankRequest;
 import com.codeit.findex.domain.indexdata.dto.response.IndexChartResponse;
+import com.codeit.findex.domain.indexdata.dto.response.IndexDataCreateResponse;
 import com.codeit.findex.domain.indexdata.dto.response.IndexDataResponse;
 import com.codeit.findex.domain.indexdata.dto.response.RankedIndexPerformanceResponse;
 import com.codeit.findex.domain.indexdata.service.IndexDataService;
@@ -102,9 +103,9 @@ public class IndexDataController {
 
   @Operation(summary = "지수 데이터 등록", description = "새로운 지수 데이터를 등록합니다.")
   @PostMapping
-  public ResponseEntity<IndexDataResponse> create(
+  public ResponseEntity<IndexDataCreateResponse> create(
       @Valid @RequestBody IndexDataCreateRequest request) {
-    IndexDataResponse response = indexDataService.create(request);
+    IndexDataCreateResponse response = indexDataService.create(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataMapper.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/IndexDataMapper.java
@@ -1,5 +1,6 @@
 package com.codeit.findex.domain.indexdata.dto;
 
+import com.codeit.findex.domain.indexdata.dto.response.IndexDataCreateResponse;
 import com.codeit.findex.domain.indexdata.dto.response.IndexPerformanceResponse;
 import com.codeit.findex.domain.indexdata.entity.IndexData;
 import java.math.BigDecimal;
@@ -32,9 +33,12 @@ public interface IndexDataMapper {
 
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "indexInfo", source = "indexInfo")
-  @Mapping(target = "sourceType", source = "request.sourceType")
-// toEntity -> toIndexData로 이름을 더 명확하게 변경했습니다.
+  @Mapping(target = "sourceType", source = "indexInfo.sourceType")
   IndexData toIndexData(IndexDataCreateRequest request, IndexInfo indexInfo);
+
+  @Mapping(source = "indexInfo.id", target = "indexInfoId")
+  @Mapping(source = "indexInfo.sourceType", target = "sourceType")
+  IndexDataCreateResponse toIndexCreateResponse(IndexData indexData);
 
 
   @Mapping(source = "currentData.indexInfo.id", target = "indexInfoId")

--- a/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexDataCreateResponse.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/dto/response/IndexDataCreateResponse.java
@@ -1,16 +1,14 @@
-package com.codeit.findex.domain.indexdata.dto.request;
+package com.codeit.findex.domain.indexdata.dto.response;
 
-import jakarta.validation.constraints.NotNull;
+import com.codeit.findex.domain.common.enums.SourceType;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-public record IndexDataCreateRequest(
-        @NotNull(message = "지수 정보 ID는 필수입니다.")
+public record IndexDataCreateResponse(
+        Long id,
         Long indexInfoId,
-
-        @NotNull(message = "기준 일자는 필수입니다.")
         LocalDate baseDate,
-
+        SourceType sourceType,
         BigDecimal marketPrice,
         BigDecimal closingPrice,
         BigDecimal highPrice,

--- a/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
+++ b/src/main/java/com/codeit/findex/domain/indexdata/service/IndexDataService.java
@@ -9,11 +9,7 @@ import com.codeit.findex.domain.indexdata.dto.request.IndexDataUpdateRequest;
 import com.codeit.findex.domain.indexdata.dto.request.IndexPerformanceRankRequest;
 import com.codeit.findex.domain.indexdata.dto.request.PeriodType;
 import com.codeit.findex.domain.indexdata.dto.request.UnitPeriodType;
-import com.codeit.findex.domain.indexdata.dto.response.ChartDataPoint;
-import com.codeit.findex.domain.indexdata.dto.response.IndexChartResponse;
-import com.codeit.findex.domain.indexdata.dto.response.IndexDataResponse;
-import com.codeit.findex.domain.indexdata.dto.response.IndexPerformanceResponse;
-import com.codeit.findex.domain.indexdata.dto.response.RankedIndexPerformanceResponse;
+import com.codeit.findex.domain.indexdata.dto.response.*;
 import com.codeit.findex.domain.indexdata.entity.IndexData;
 import com.codeit.findex.domain.indexdata.repository.IndexDataRepository;
 import com.codeit.findex.domain.indexinfo.dto.IndexInfoCursorResponse;
@@ -351,24 +347,23 @@ public class IndexDataService {
   }
 
   @Transactional
-  public IndexDataResponse create(IndexDataCreateRequest request) {
-    IndexInfo indexInfo =
-        indexInfoRepository
-            .findById(request.indexInfoId())
-            .orElseThrow(
-                () ->
-                    new EntityNotFoundException(
-                        "해당 지수 정보를 찾을 수 없습니다. id=" + request.indexInfoId()));
+  public IndexDataCreateResponse create(IndexDataCreateRequest request) {
+    IndexInfo indexInfo = indexInfoRepository.findById(request.indexInfoId())
+            .orElseThrow(() -> new EntityNotFoundException("참조하는 지수 정보를 찾을 수 없습니다. ID: " + request.indexInfoId()));
 
-    if (indexDataRepository.existsByIndexInfo_IdAndBaseDate(
-        request.indexInfoId(), request.baseDate())) {
+    // 2. 날짜 중복 체크 (400)
+    if (indexDataRepository.existsByIndexInfo_IdAndBaseDate(request.indexInfoId(), request.baseDate())) {
       throw new IllegalArgumentException("해당 날짜의 데이터가 이미 존재합니다.");
     }
 
+    // 3. 변환 (Mapper가 여기서 IndexInfo의 sourceType을 IndexData에 넣어줍니다)
     IndexData indexData = indexDataMapper.toIndexData(request, indexInfo);
+
+    // 4. 저장
     IndexData savedData = indexDataRepository.save(indexData);
 
-    return indexDataMapper.toResponse(savedData);
+    // 5. 응답 반환
+    return indexDataMapper.toIndexCreateResponse(savedData);
   }
 
   @Transactional

--- a/src/main/java/com/codeit/findex/domain/indexinfo/entity/IndexInfo.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/entity/IndexInfo.java
@@ -108,6 +108,22 @@ public class IndexInfo {
         favorite);
   }
 
+  public static IndexInfo createByOpenAPI(
+          String indexClassification,
+          String indexName,
+          Integer employedItemsCount,
+          LocalDate basePointInTime,
+          BigDecimal baseIndex) {
+    return new IndexInfo(
+            indexClassification,
+            indexName,
+            employedItemsCount,
+            basePointInTime,
+            baseIndex,
+            SourceType.OPEN_API,
+            false);
+  }
+
   public void update(
       Integer employedItemsCount,
       LocalDate basePointInTime,

--- a/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/codeit/findex/domain/indexinfo/service/IndexInfoService.java
@@ -88,6 +88,9 @@ public class IndexInfoService {
     // 3. DB 저장
     IndexInfo savedIndexInfo = indexInfoRepository.save(newIndexInfo);
 
+    // 4. auto_sync_config 데이터 넣기
+
+
     return indexInfoMapper.toIndexInfoResponse(savedIndexInfo);
   }
 

--- a/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/codeit/findex/domain/syncjob/service/SyncJobService.java
@@ -1,5 +1,7 @@
 package com.codeit.findex.domain.syncjob.service;
 
+import com.codeit.findex.domain.autosyncconfig.entity.AutoSyncConfig;
+import com.codeit.findex.domain.autosyncconfig.repository.AutoSyncConfigRepository;
 import com.codeit.findex.domain.common.enums.JobType;
 import com.codeit.findex.domain.common.enums.SourceType;
 import com.codeit.findex.domain.common.enums.SyncResult;
@@ -59,6 +61,9 @@ public class SyncJobService {
   private final SyncJobMapper syncJobMapper;
   private final PlatformTransactionManager transactionManager;
 
+  // 자동 연동 설정 테이블
+  private final AutoSyncConfigRepository autoSyncConfigRepository;
+
   @Transactional
   public List<IndexInfoSyncJobResponse> syncIndexInfos(String worker) {
     String resolvedWorker = (worker == null || worker.isBlank()) ? "system" : worker;
@@ -99,36 +104,39 @@ public class SyncJobService {
     LocalDate targetDate = (row == null) ? null : row.basePointInTime();
 
     try {
-      return executeInNewTransaction(() -> {
-      validateIndexInfosRow(row);
+      return executeInNewTransaction(
+          () -> {
+            validateIndexInfosRow(row);
 
-      IndexInfo indexInfo = upsertIndexInfos(row);
+            IndexInfo indexInfo = upsertIndexInfos(row);
 
-      SyncJob successJob =
-          SyncJob.create(
-              null,
-              JobType.INDEX_INFO,
-              indexInfo,
-              targetDate,
-              worker,
-              LocalDateTime.now(),
-              SyncResult.SUCCESS);
-      return syncJobRepository.save(successJob);
-      });
+            SyncJob successJob =
+                SyncJob.create(
+                    null,
+                    JobType.INDEX_INFO,
+                    indexInfo,
+                    targetDate,
+                    worker,
+                    LocalDateTime.now(),
+                    SyncResult.SUCCESS);
+            return syncJobRepository.save(successJob);
+          });
     } catch (RuntimeException e) {
-      return executeInNewTransaction(() -> {
-      SyncJob failedJob =
-          SyncJob.create(
-              null,
-              JobType.INDEX_INFO,
-              null,
-              targetDate,
-              worker,
-              LocalDateTime.now(),
-              SyncResult.FAILED);
-      return syncJobRepository.save(failedJob);
-    });
-  }}
+      return executeInNewTransaction(
+          () -> {
+            SyncJob failedJob =
+                SyncJob.create(
+                    null,
+                    JobType.INDEX_INFO,
+                    null,
+                    targetDate,
+                    worker,
+                    LocalDateTime.now(),
+                    SyncResult.FAILED);
+            return syncJobRepository.save(failedJob);
+          });
+    }
+  }
 
   private void validateIndexInfosRow(OpenApiIndexInfoResponse row) {
     if (row.employedItemsCount() == null) {
@@ -155,16 +163,22 @@ public class SyncJobService {
               return existing;
             })
         .orElseGet(
-            () ->
-                indexInfoRepository.save(
-                    IndexInfo.create(
-                        row.indexClassification(),
-                        row.indexName(),
-                        row.employedItemsCount(),
-                        row.basePointInTime(),
-                        row.baseIndex(),
-                        SourceType.OPEN_API,
-                        false)));
+            () -> {
+              IndexInfo newIndexInfo =
+                  IndexInfo.createByOpenAPI(
+                      row.indexClassification(),
+                      row.indexName(),
+                      row.employedItemsCount(),
+                      row.basePointInTime(),
+                      row.baseIndex());
+              IndexInfo savedIndexInfo = indexInfoRepository.save(newIndexInfo);
+
+              // 새로운 지수이면 테이블에 데이터 밀어넣기
+              AutoSyncConfig syncConfig = AutoSyncConfig.create(savedIndexInfo, true);
+              autoSyncConfigRepository.save(syncConfig);
+
+              return savedIndexInfo;
+            });
   }
 
   @Transactional

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,5 +27,5 @@ spring:
 open-api:
   stock-index:
     base-url: https://apis.data.go.kr/1160100/service/GetMarketIndexInfoService/getStockMarketIndex
-    service-key: ${OPEN_API_STOCK_INDEX_SERVICE_KEY:}
+    service-key: 0ef32bf2fa093ed68f76e0384f83b3cd2721c419c102217d970de88c22cedaae
     num-of-rows: 100


### PR DESCRIPTION
## 작업 내용
수동으로 지수 데이터를 등록하는 API를 버그를 수정하고, 시스템을 통해 자동 수집되는 지수(OPEN_API)에 대한 스케줄러 동기화 설정(`AutoSyncConfig`) 자동 연동 로직을 구축했습니다.

## 변경 사항
- **[Feature] 지수 데이터 수동 등록 API (`POST /api/index-data`)**
  - 명세서에 맞춰 Request/Response DTO를 구현했습니다.
  - **데이터 무결성 로직:** 클라이언트에게 `sourceType`을 입력받지 않고, 백엔드(`IndexDataMapper`)에서 부모인 `IndexInfo`의 `sourceType`을 자동으로 상속받아 주입하도록 설계하여 데이터 성격이 어긋나는 문제를 원천 차단했습니다.

- **[Feature] 스케줄러 자동 연동 분기 처리 (`SyncJobService`)**
  - **수동 생성 (USER):** `POST /api/index-info`로 사용자가 직접 만든 지수는 스케줄러가 돌지 않도록 `AutoSyncConfig`를 생성하지 않는 정책을 적용했습니다.
  - **자동 수집 (OPEN_API):** `SyncJobService`를 통해 외부 API에서 신규 지수가 DB에 최초로 등록될 때(`upsertIndexInfos`, `findOrCreateIndexInfo`), `AutoSyncConfig.create(indexInfo, true)`를 호출하여 스케줄러 대상(`enabled=true`)으로 자동 등록되도록 수정했습니다.

## 테스트
- [x] 실제 클라이언트랑 통합 테스트
- [x] 컨벤션 부합 여부